### PR TITLE
Fix GitHub node12 deprecation by updating it to node 16

### DIFF
--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -222,7 +222,7 @@ jobs:
           secret: ${{ steps.generate_token.outputs.token }}
           approvers: ${{ inputs.APPROVERS }}
           minimum-approvals: 1
-          issue-title: "Terragrunt approval pending for ${{ github.job }}"
+          issue-title: "Terragrunt approval pending for ${{ inputs.WORKING_DIR }}"
 
       - name: Terragrunt apply-all
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -97,7 +97,7 @@ jobs:
           ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY_TFMODULES }}
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
@@ -222,7 +222,7 @@ jobs:
           secret: ${{ steps.generate_token.outputs.token }}
           approvers: ${{ inputs.APPROVERS }}
           minimum-approvals: 1
-          issue-title: "Terragrunt approval pending for ${{ inputs.WORKING_DIR }}"
+          issue-title: "Terragrunt approval pending for ${{ github.job }}"
 
       - name: Terragrunt apply-all
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
It solves the deprecation warnings that we see while connecting to the remote backend for state files.