### PR TITLE
disable load in case of multi-platform build

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -100,6 +100,7 @@ runs:
 
     - name: Build and export to Docker
       uses: docker/build-push-action@v4
+      if: inputs.PLATFORMS == 'linux/amd64'
       with:
         load: true
         tags: |

--- a/.github/actions/test-ruby/action.yml
+++ b/.github/actions/test-ruby/action.yml
@@ -19,12 +19,22 @@ runs:
     - name: Run Tests
       run: |
         cp .env.example .env
+<<<<<<< Updated upstream
         bundle install --path ./bundle --without production,development > /dev/null
         bundle exec rake db:test:prepare > /dev/null
         bundle exec rake core:db:test:prepare > /dev/null
         bundle exec rake messaging:db:test:prepare > /dev/null
+=======
+        bundle config set gems.contribsys.com $CONTRIBSYS_CREDENTIALS
+        bundle install --path ./bundle --without production,development 
+        bundle exec rake db:test:prepare 
+        bundle exec rake core:db:test:prepare 
+        bundle exec rake messaging:db:test:prepare 
+>>>>>>> Stashed changes
         bundle exec rspec -f j -o tmp/rspec_results.json -f p
       shell: bash
+      env:
+        CONTRIBSYS_CREDENTIALS: ${{ env.CONTRIBSYS_CREDENTIALS }}
     
     - name: RSpec Report
       uses: SonicGarden/rspec-report-action@v2

--- a/.github/actions/test-ruby/action.yml
+++ b/.github/actions/test-ruby/action.yml
@@ -19,18 +19,10 @@ runs:
     - name: Run Tests
       run: |
         cp .env.example .env
-<<<<<<< Updated upstream
         bundle install --path ./bundle --without production,development > /dev/null
         bundle exec rake db:test:prepare > /dev/null
         bundle exec rake core:db:test:prepare > /dev/null
         bundle exec rake messaging:db:test:prepare > /dev/null
-=======
-        bundle config set gems.contribsys.com $CONTRIBSYS_CREDENTIALS
-        bundle install --path ./bundle --without production,development 
-        bundle exec rake db:test:prepare 
-        bundle exec rake core:db:test:prepare 
-        bundle exec rake messaging:db:test:prepare 
->>>>>>> Stashed changes
         bundle exec rspec -f j -o tmp/rspec_results.json -f p
       shell: bash
       env:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -24,7 +24,7 @@ on:
       RUBY_VERSION:
         required: false
         type: string
-        default: "2.7.4"
+        description: Default Ruby version
       TEST_DEPENDENCIES:
         required: false
         type: boolean
@@ -57,6 +57,8 @@ on:
       DOCKERHUB_TOKEN:
         required: false
       GH_BOT_DEPLOY_KEY:
+        required: false
+      CONTRIBSYS_CREDENTIALS:
         required: false
       
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -112,6 +114,7 @@ jobs:
         RUBY_VERSION: ${{ inputs.RUBY_VERSION }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CONTRIBSYS_CREDENTIALS: ${{ secrets.CONTRIBSYS_CREDENTIALS }}
     
     - name: SonarQube Coverage
       if: ${{ inputs.COVERAGE == true }}


### PR DESCRIPTION
Docker buildx can't export manifest in case of multi-platform builds e.g. 
https://github.com/signalwire/devops-base-images/actions/runs/4107251005/jobs/7086492483#step:10:442

This commit bypass this step in our workflows