### PR TITLE
update cd k8s + helm action local to support inline values

### DIFF
--- a/.github/actions/helm-local/action.yml
+++ b/.github/actions/helm-local/action.yml
@@ -4,12 +4,20 @@ description: Deploy a local Helm Chart to a Kubernetes Cluster
 inputs:
   APP_NAME:
     required: true
+    description: Kubernetes app name.
   CHART_PATH:
     required: true
+    description: Chart path as context
   NAMESPACE:
     required: true
+    description: Namespace where the app will be deployed
   VALUES_FILE:  
     required: true
+    description: Default values file
+  INLINE_VALUES:
+    required: false
+    description: Inline values, commonly used to hide secrets
+
         
 runs:
   using: "composite"
@@ -24,5 +32,5 @@ runs:
       shell: bash
 
     - name: Helm upgrade --install
-      run: helm upgrade ${{ inputs.APP_NAME }} ${{ inputs.CHART_PATH }} --install --create-namespace --namespace=${{ inputs.NAMESPACE }} -f=${{ inputs.VALUES_FILE }}
+      run: helm upgrade ${{ inputs.APP_NAME }} ${{ inputs.CHART_PATH }} --install --create-namespace --namespace=${{ inputs.NAMESPACE }} -f=${{ inputs.VALUES_FILE }} --set ${{ inputs.INLINE_VALUES }}
       shell: bash

--- a/.github/workflows/cd-kubernetes-deploy.yml
+++ b/.github/workflows/cd-kubernetes-deploy.yml
@@ -46,6 +46,11 @@ on:
       VALUES_FILE_PATH:  
         required: true
         type: string
+      INLINE_VALUES:
+        required: false
+        type: string
+        default: ''
+        description: Inline values, commonly used to hide secrets. Key-Value comma-separated e.g. key1=val1,key2=val2
     secrets:
       TELEPORT_CA_PIN:
         required: false
@@ -107,5 +112,6 @@ jobs:
         CHART_PATH: ${{ inputs.CHART_PATH }}
         NAMESPACE: ${{ inputs.NAMESPACE }}
         VALUES_FILE: ${{ inputs.VALUES_FILE_PATH }}
+        INLINE_VALUES: ${{ inputs.INLINE_VALUES }}
 
 


### PR DESCRIPTION
Implements the ```--set``` flag for Helm. 
Fulfills the need raised by https://github.com/signalwire/charts/pull/11