### PR TITLE
add non-interactive flag

### DIFF
--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -145,7 +145,7 @@ jobs:
       
       - name: Terragrunt validate
         id: validate
-        run: terragrunt run-all validate
+        run: terragrunt run-all validate --terragrunt-non-interactive
         working-directory: ${{ inputs.WORKING_DIR }}
 
       - name: Terragrunt plan


### PR DESCRIPTION
solves cross-project communication such as (https://github.com/signalwire/infrastructure-lives/actions/runs/4758011637/jobs/8455522130)