### PR TITLE
Path is only for directory

### DIFF
--- a/.github/actions/test-dotnet/action.yml
+++ b/.github/actions/test-dotnet/action.yml
@@ -45,7 +45,8 @@ runs:
     - name: Load .env file
       uses: xom9ikk/dotenv@v2
       with:
-        path: .env.ci
+        mode: ci
+        load-mode: skip
 
     - name: Test
       run: dotnet test --logger "trx;LogFileName=test-results.trx" -p:DefineConstants=LOCALTESTING || true


### PR DESCRIPTION
https://github.com/xom9ikk/dotenv

```
Run xom9ikk/dotenv@v2
  with:
    path: .env.ci
  env:
    DOTNET_ROOT: /usr/share/dotnet
Error: ENOTDIR: not a directory, open '.env.ci/.env'
```