### PR TITLE
Remove failing step

### DIFF
--- a/.github/actions/test-dotnet/action.yml
+++ b/.github/actions/test-dotnet/action.yml
@@ -53,11 +53,6 @@ runs:
       if: inputs.RUN_TESTS != 'false'
       shell: bash
 
-    - name: Workaround tests
-      run: chown runner:docker -R **/test-results.trx
-      shell: bash
-      continue-on-error: true
-
     - name: Test Report
       uses: dorny/test-reporter@v1
       if: always() && inputs.RUN_TESTS == 'true'


### PR DESCRIPTION
This step appears to be failing consistently across repos. The GHA runs, overall, are still succeeded, but this failure shows in the results as a failure.
![Screenshot 2023-06-06 at 4 03 42 PM](https://github.com/signalwire/actions-template/assets/49515/2f06f5c1-3b54-45eb-8a91-8aa9840c6c93)
