### PR TITLE
Remove id-token write permission

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -144,7 +144,6 @@ jobs:
     environment: ${{ inputs.ENVIRONMENT }}
     name: BUILD
     permissions:
-      id-token: write
       contents: read
     outputs:
       IMAGE_TAG: ${{ steps.build.outputs.IMAGE_TAG }}


### PR DESCRIPTION
Is it necessary? When attempting to use the `permissions` key as mentioned in https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/ , the GHA fails with

```
The workflow is not valid. signalwire/actions-template/.github/workflows/ci.yml@main (Line: 209, Col: 3): Error calling workflow 'signalwire/actions-template/.github/workflows/ci-build.yml@main'. The nested job 'build' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

Example PR: https://github.com/signalwire/taxman/pull/298
The GHA run: https://github.com/signalwire/taxman/actions/runs/5664940013

So, now any repo that wants to set the `permissions` has to be aware of the `id-token` permission, which caused me some confusion and may cause others as well?

As far as I can tell, the id-token is used for OpenID Connect (https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)

Do we use OpenID Connect though?
