### PR TITLE
Fix/run script escapes

### DIFF
--- a/.github/workflows/ci-deb-packages-v2.yml
+++ b/.github/workflows/ci-deb-packages-v2.yml
@@ -49,7 +49,7 @@ jobs:
         cat > run.sh <<EOF
         #!/bin/bash
 
-        dch -b -M -v "\$(dpkg-parsechangelog --show-field Version | cut -f1 -d"-")-\$GITHUB_RUN_ID~\$(echo \$GITHUB_SHA | cut -c1-10)~\$(lsb_release -cs)" --force-distribution -D "\$(lsb_release -cs)" "Nightly build, \$(echo \$GITHUB_SHA | cut -c1-10)" 
+        dch -b -M -v "\$(dpkg-parsechangelog --show-field Version | cut -f1 -d"-")-$GITHUB_RUN_ID~\$(echo $GITHUB_SHA | cut -c1-10)~\$(lsb_release -cs)" --force-distribution -D "\$(lsb_release -cs)" "Nightly build, \$(echo $GITHUB_SHA | cut -c1-10)" 
         debuild -b -us -uc 
         ls -la ..
         mv ../*.deb .

--- a/.github/workflows/ci-deb-packages-v2.yml
+++ b/.github/workflows/ci-deb-packages-v2.yml
@@ -49,7 +49,7 @@ jobs:
         cat > run.sh <<EOF
         #!/bin/bash
 
-        dch -b -M -v "`dpkg-parsechangelog --show-field Version | cut -f1 -d"-"`-$GITHUB_RUN_ID~`echo $GITHUB_SHA | cut -c1-10`~`lsb_release -cs`" --force-distribution -D "`lsb_release -cs`" "Nightly build, `echo $GITHUB_SHA | cut -c1-10`" 
+        dch -b -M -v "\$(dpkg-parsechangelog --show-field Version | cut -f1 -d"-")-\$GITHUB_RUN_ID~\$(echo \$GITHUB_SHA | cut -c1-10)~\$(lsb_release -cs)" --force-distribution -D "\$(lsb_release -cs)" "Nightly build, \$(echo \$GITHUB_SHA | cut -c1-10)" 
         debuild -b -us -uc 
         ls -la ..
         mv ../*.deb .


### PR DESCRIPTION
Scripts generated in the workflow for use later on to build debian packages were evaluating some commands at the wrong time, generating incorrect build artifacts. This PR adds subcommand escapes in the appropriate places to generate a correct script.