### PR TITLE
GHA packaging: Rework Sync changes.

### DIFF
--- a/.github/workflows/cd-libs-metadata.yml
+++ b/.github/workflows/cd-libs-metadata.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Checkout metadatarepo
         uses: actions/checkout@v4
-        continue-on-error: true
+        continue-on-error: false
         id: metabranch
         with:
           repository: ${{ inputs.TARGET_REPO }}
@@ -97,11 +97,9 @@ jobs:
       - name: Sync changes
         shell: sh
         run: |
-          git checkout ${{ inputs.LIB_NAME }}/${{ inputs.TARGET_OS }}/${{ inputs.TARGET_PLATFORM }}
-          git pull
-          git status --porcelain && exit 0
-          git add metafile.txt
+          git status --porcelain | grep -q . || exit 0
           git config --global user.email "github-actions@github.com"
           git config --global user.name "github-actions"
-          git commit -m "update metadata"
-          git push
+          git add -v metafile.txt
+          git commit --branch -m "update metadata"
+          git push --atomic -v


### PR DESCRIPTION
Rework handling of `Sync changes` in case when there are no changes to commit and remove redundant git branch checkouts.

Related to GHA packaging.