### PR TITLE
Change DEB version format.

### DIFF
--- a/.github/workflows/ci-deb-packages-v2.yml
+++ b/.github/workflows/ci-deb-packages-v2.yml
@@ -92,7 +92,7 @@ jobs:
         hash=$(echo $GITHUB_SHA | cut -c1-10)
 
         # deb package version
-        dch_version=\${version}-${GITHUB_RUN_ID}~\${hash}~\${lsb}
+        dch_version=\${version}-${GITHUB_RUN_ID}-\${hash}~\${lsb}
         echo "dch_version: \${dch_version}"
 
         dch -b -M -v "\${dch_version}" --force-distribution -D "\${lsb}" "Nightly build, \${hash}"


### PR DESCRIPTION
As per https://www.debian.org/doc/debian-policy/ch-controlfields.html#version we want to have only single `~` character in the version string and it must be the last splitter component of the entire version string.

Having multiple `~` in version string makes version comparison very unintuitive.

Consider this example:

```
0.1.0-999~buster-u1 > 0.1.0-7785001901~ef9e94e4f6~buster
0.1.0-999~buster-u1 < 0.1.0-7785001901-ef9e94e4f6~buster
0.1.0-999~buster < 0.1.0-7785001901~ef9e94e4f6~buster
0.1.0-999~buster < 0.1.0-7785001901-ef9e94e4f6~buster
```