### PR TITLE
Revert "Change version delimiter for CMake."

### DIFF
--- a/.github/workflows/ci-deb-packages-v2.yml
+++ b/.github/workflows/ci-deb-packages-v2.yml
@@ -172,7 +172,7 @@ jobs:
         # eval inside runner
         hash=$(echo $GITHUB_SHA | cut -c1-10)
 
-        PACKAGE_RELEASE="$GITHUB_RUN_ID-\${hash}" cmake . -DCMAKE_BUILD_TYPE=${{ inputs.CMAKE_BUILD_TYPE }} -DCMAKE_INSTALL_PREFIX=${{ inputs.CMAKE_INSTALL_PREFIX }} && make package
+        PACKAGE_RELEASE="$GITHUB_RUN_ID.\${hash}" cmake . -DCMAKE_BUILD_TYPE=${{ inputs.CMAKE_BUILD_TYPE }} -DCMAKE_INSTALL_PREFIX=${{ inputs.CMAKE_INSTALL_PREFIX }} && make package
 
         EOF
 


### PR DESCRIPTION
Reverts signalwire/actions-template#223

```
CPackDeb: Debian package release must confirm to "^[A-Za-z0-9.+~]+$" regex!
```