### PR TITLE
Fail the job when deploy fails

### DIFF
--- a/.github/actions/swarm-deploy/action.yml
+++ b/.github/actions/swarm-deploy/action.yml
@@ -40,7 +40,7 @@ runs:
           
           jq '.Spec.TaskTemplate.ContainerSpec.Image="${{ inputs.IMAGE_TAG}}" | .Spec' service.spec.json > update.spec.json
           
-            curl -s -X POST -H "X-API-Key: ${{env.PORTAINER_API_KEY}}" -H "Content-Type: application/json" ${{inputs.PORTAINER_DOMAIN_PROTOCOL}}://${{inputs.PORTAINER_DOMAIN}}/api/endpoints/${{env.ENDPOINT_ID}}/docker/services/${{ inputs.STACK_NAME }}/update?version=$version -d @update.spec.json
+          curl -f -s -X POST -H "X-API-Key: ${{env.PORTAINER_API_KEY}}" -H "Content-Type: application/json" ${{inputs.PORTAINER_DOMAIN_PROTOCOL}}://${{inputs.PORTAINER_DOMAIN}}/api/endpoints/${{env.ENDPOINT_ID}}/docker/services/${{ inputs.STACK_NAME }}/update?version=$version -d @update.spec.json
           
           echo PREVIOUS_IMAGE=$previousimg >> $GITHUB_OUTPUT
           echo DEPLOYED_DATE=$(date -u) >> $GITHUB_OUTPUT


### PR DESCRIPTION
Currently, the job is green even when the deploy fails. This causes confusion and extra work to debug.