### PR TITLE
Add `Wait for Docker daemon` to `docker-build-artifacts`

### DIFF
--- a/.github/actions/docker-build-artifacts/action.yml
+++ b/.github/actions/docker-build-artifacts/action.yml
@@ -33,6 +33,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Wait for Docker daemon
+      shell: bash
+      run: |
+        until docker info >/dev/null 2>&1; do
+          if [ $SECONDS -ge 60 ]; then
+            echo "Timeout waiting for Docker daemon"
+            exit 1
+          fi
+          sleep 1
+        done
+
     - name: Set up QEMU for Docker
       uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
Add Docker daemon waiter with deadline of 60 seconds, should help with random fails that are happening on new `arm` runners.

Example of fail:

```
  /usr/bin/docker version
  Client: Docker Engine - Community
   Version:           26.1.3
   API version:       1.45
   Go version:        go1.21.10
   Git commit:        b72abbb
   Built:             Thu May 16 08:40:13 2024
   OS/Arch:           linux/arm64
   Context:           default
  Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
Error: The process '/usr/bin/docker' failed with exit code 1
```