### PR TITLE
fix: remove colons from branch names

### DIFF
--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -95,5 +95,6 @@ runs:
       if: inputs.CREATE_PR == 'true'
       working-directory: gitops
       run: |
-          git push -u origin deploy-${{ inputs.SERVICE_NAME }}-${{ inputs.IMAGE_TAG }}
+          BRANCH_NAME="deploy-${{ inputs.SERVICE_NAME }}-${{ inputs.IMAGE_TAG//:/- }}"
+          git push -u origin $BRANCH_NAME
           gh pr create --title "Update image tag for ${{ inputs.SERVICE_NAME }}" --body "Update image tag for ${{ inputs.SERVICE_NAME }}"


### PR DESCRIPTION
when given an image with colon, there is an error

```
fatal: 'deploy-service-name-org/service:20250314-848-562f955' is not a valid branch name
```

