### PR TITLE
fix: Separate GHA and bash substitution

### DIFF
--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -95,6 +95,7 @@ runs:
       if: inputs.CREATE_PR == 'true'
       working-directory: gitops
       run: |
-          BRANCH_NAME="deploy-${{ inputs.SERVICE_NAME }}-${{ inputs.IMAGE_TAG//:/- }}"
-          git push -u origin $BRANCH_NAME
+          BRANCH_NAME="deploy-${{ inputs.SERVICE_NAME }}-${{ inputs.IMAGE_TAG }}"
+          BRANCH_NAME=${BRANCH_NAME//:/-}
+          git push -u origin "$BRANCH_NAME"
           gh pr create --title "Update image tag for ${{ inputs.SERVICE_NAME }}" --body "Update image tag for ${{ inputs.SERVICE_NAME }}"


### PR DESCRIPTION
Get the variable into bash, then substitute. error 

```
signalwire/actions-template/main/.github/actions/update-gitops/action.yml (Line: 97, Col: 12): Unexpected symbol: 'IMAGE_TAG//:/-'. Located at position 8 within expression: inputs.IMAGE_TAG//:/-
```
