### PR TITLE
fix: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN

### DIFF
--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
     description: The branch name to create if CREATE_PR is true.
   GH_TOKEN:
-    description: 'GitHub Token for authentication'
+    description: GitHub Token for authentication
     required: false
 
 runs:

--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -31,6 +31,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate inputs
+      run: |
+        if [ "${{ inputs.CREATE_PR }}" == "true" ] && [ -z "${{ inputs.GH_TOKEN }}" ]; then
+          echo "GH_TOKEN is required when CREATE_PR is true."
+          exit 1
+        fi
+      shell: bash
+
     - name: Checkout GitOps repo
       uses: actions/checkout@v4
       with:

--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: The branch name to create if CREATE_PR is true.
   GH_TOKEN:
     description: 'GitHub Token for authentication'
-    required: true
+    required: false
 
 runs:
   using: "composite"

--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -24,6 +24,9 @@ inputs:
   BRANCH_NAME:
     required: false
     description: The branch name to create if CREATE_PR is true.
+  GH_TOKEN:
+    description: 'GitHub Token for authentication'
+    required: true
 
 runs:
   using: "composite"
@@ -106,6 +109,8 @@ runs:
       shell: bash
       if: inputs.CREATE_PR == 'true'
       working-directory: gitops
+      env:
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
       run: |
           git push -u origin "$BRANCH_NAME"
           gh pr create --title "Update image tag for ${{ inputs.SERVICE_NAME }}" --body "Update image tag for ${{ inputs.SERVICE_NAME }}"

--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -25,8 +25,8 @@ inputs:
     required: false
     description: The branch name to create if CREATE_PR is true.
   GH_TOKEN:
-    description: GitHub Token for authentication
     required: false
+    description: GitHub Token for authentication
 
 runs:
   using: "composite"


### PR DESCRIPTION
To use the gh cli to create a PR, we need the token.

error
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```