### PR TITLE
Disable rspec report comment

### DIFF
--- a/.github/actions/test-ruby/action.yml
+++ b/.github/actions/test-ruby/action.yml
@@ -149,3 +149,4 @@ runs:
       with:
         token: ${{ env.GITHUB_TOKEN }}
         json-path: tmp/rspec_results.json
+        comment: false


### PR DESCRIPTION
appears new in [v6, merged last week](https://github.com/signalwire/actions-template/commit/a666f0dbb8d34fbab53d5e4b308d6f1634f2242c), causing too many PR CI failures