### PR TITLE
Revert "chore(deps): update sonicgarden/rspec-report-action action to v6"

### DIFF
--- a/.github/actions/test-ruby/action.yml
+++ b/.github/actions/test-ruby/action.yml
@@ -145,7 +145,7 @@ runs:
     
     - name: RSpec Report
       if: always()
-      uses: SonicGarden/rspec-report-action@v6
+      uses: SonicGarden/rspec-report-action@v5
       with:
         token: ${{ env.GITHUB_TOKEN }}
         json-path: tmp/rspec_results.json

--- a/.github/actions/test-ruby/action.yml
+++ b/.github/actions/test-ruby/action.yml
@@ -149,4 +149,3 @@ runs:
       with:
         token: ${{ env.GITHUB_TOKEN }}
         json-path: tmp/rspec_results.json
-        comment: false


### PR DESCRIPTION
Reverts signalwire/actions-template#344

ci is still failing after disabling comment, reverting to previous version