### PR TITLE
Add TERRAGRUNT_EXCLUDE_DIR to IaC workflow

### DIFF
--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -38,6 +38,11 @@ on:
         type: string
         default: ''
         description: An app registered on teleport to authenticate using proxy
+      TERRAGRUNT_EXCLUDE_DIR:
+        required: false
+        type: string
+        default: ''
+        description: A comma-separated list of UNIX style globs of directories to ignore
       GCP_WIP:
         required: false
         type: string
@@ -214,6 +219,7 @@ jobs:
           # print git configuration
           INPUT_PRE_EXEC_2: |
             git config --global --list
+          TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
       
       - name: Validate
         uses: gruntwork-io/terragrunt-action@v2.1.4
@@ -225,6 +231,7 @@ jobs:
           tg_command: 'run-all validate'
         env:
           OVH_CLOUD_PROJECT_SERVICE: ${{ secrets.OVH_CLOUD_PROJECT_SERVICE }}
+          TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
       
       - name: Plan
         uses: gruntwork-io/terragrunt-action@v2.1.4
@@ -253,6 +260,7 @@ jobs:
           OVH_CLOUD_PROJECT_SERVICE: ${{ secrets.OVH_CLOUD_PROJECT_SERVICE }}
           GITHUB_TOKEN: ${{ github.token }}
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
           # TF_LOG: trace
 
       - name: Generate token
@@ -298,6 +306,7 @@ jobs:
           OVH_CONSUMER_KEY: ${{ secrets.OVH_CONSUMER_KEY }}
           OVH_CLOUD_PROJECT_SERVICE: ${{ secrets.OVH_CLOUD_PROJECT_SERVICE }}
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
 
       - run: sudo chmod -R 777 /home/runner/_work/${{ github.event.repository.name }}
         continue-on-error: true

--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -220,7 +220,8 @@ jobs:
           INPUT_PRE_EXEC_2: |
             git config --global --list
           TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
-      
+          TG_QUEUE_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
+
       - name: Validate
         uses: gruntwork-io/terragrunt-action@v2.1.4
         id: validate
@@ -232,7 +233,8 @@ jobs:
         env:
           OVH_CLOUD_PROJECT_SERVICE: ${{ secrets.OVH_CLOUD_PROJECT_SERVICE }}
           TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
-      
+          TG_QUEUE_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
+
       - name: Plan
         uses: gruntwork-io/terragrunt-action@v2.1.4
         id: plan
@@ -261,6 +263,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
+          TG_QUEUE_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
           # TF_LOG: trace
 
       - name: Generate token
@@ -307,6 +310,7 @@ jobs:
           OVH_CLOUD_PROJECT_SERVICE: ${{ secrets.OVH_CLOUD_PROJECT_SERVICE }}
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
+          TG_QUEUE_EXCLUDE_DIR: ${{ inputs.TERRAGRUNT_EXCLUDE_DIR }}
 
       - run: sudo chmod -R 777 /home/runner/_work/${{ github.event.repository.name }}
         continue-on-error: true


### PR DESCRIPTION
This PR adds an optional input that allows IaC workflow runs to optionally skip one or more specified directories.

The behavior of this change has been tested locally with Terragrunt `v0.79,2` and `v0.58.2` (currently the workflow default) as well as with IaC planning runs on another PR that references this feature branch (https://github.com/signalwire/infrastructure-lives/pull/1258).

Note that both `TERRAGRUNT_EXCLUDE_DIR` and `TG_QUEUE_EXCLUDE_DIR` are set; this is to ensure compatibility with newer versions of Terragrunt.