### PR TITLE
Add targeted swarm service updates to GitOps workflow

### DIFF
--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'The file path in the GitOps repository to update'
     required: true
   SERVICE_NAME:
-    description: 'The name of the service (based on docker image repo) to update'
+    description: 'The name of the service (based on docker image repo name) to update'
     required: true
   SWARM_SERVICE_NAME:
     description: 'The specific swarm service name to update'

--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'The new image tag to push'
     required: true
   SWARM_SERVICE_NAME:
-    description: 'The specific swarm service name to update (e.g., us-west)'
+    description: 'The specific swarm service name to update'
     required: false
   ORCHESTRATOR:
     required: true

--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -9,14 +9,14 @@ inputs:
     description: 'The file path in the GitOps repository to update'
     required: true
   SERVICE_NAME:
-    description: 'The name of the service to update'
-    required: true
-  IMAGE_TAG:
-    description: 'The new image tag to push'
+    description: 'The name of the service (based on docker image repo) to update'
     required: true
   SWARM_SERVICE_NAME:
     description: 'The specific swarm service name to update'
     required: false
+  IMAGE_TAG:
+    description: 'The new image tag to push'
+    required: true
   ORCHESTRATOR:
     required: true
     default: swarm

--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -14,6 +14,9 @@ inputs:
   IMAGE_TAG:
     description: 'The new image tag to push'
     required: true
+  SWARM_SERVICE_NAME:
+    description: 'The specific swarm service name to update (e.g., us-west)'
+    required: false
   ORCHESTRATOR:
     required: true
     default: swarm
@@ -72,13 +75,24 @@ runs:
         FILE_PATH: ${{ inputs.FILE_PATH }}
         SERVICE_NAME: ${{ inputs.SERVICE_NAME }}
         IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
+        SWARM_SERVICE_NAME: ${{ inputs.SWARM_SERVICE_NAME }}
       working-directory: gitops
       run: |
         set -x
-        echo "$FILE_PATH"
-        echo "$SERVICE_NAME"
-        echo "$IMAGE_TAG"
-        sed -i "s|image: signalwire/${SERVICE_NAME}:[^ ]*|image: ${IMAGE_TAG}|" "$FILE_PATH"
+        echo "FILE_PATH: $FILE_PATH"
+        echo "SERVICE_NAME: $SERVICE_NAME"
+        echo "IMAGE_TAG: $IMAGE_TAG"
+        echo "SWARM_SERVICE_NAME: $SWARM_SERVICE_NAME"
+        
+        if [ -n "$SWARM_SERVICE_NAME" ]; then
+          # Update specific swarm service by service name
+          # Find the service section and update the image line that follows
+          sed -i "/^  ${SWARM_SERVICE_NAME}:/,/^  [^[:space:]]/ s|^    image: .*|    image: ${IMAGE_TAG}|" "$FILE_PATH"
+        else
+          # Original behavior: update all services with matching image name pattern
+          sed -i "s|image: signalwire/${SERVICE_NAME}:[^ ]*|image: ${IMAGE_TAG}|" "$FILE_PATH"
+        fi
+        
         git status
         git diff
     

--- a/.github/actions/update-gitops/action.yml
+++ b/.github/actions/update-gitops/action.yml
@@ -81,8 +81,8 @@ runs:
         set -x
         echo "FILE_PATH: $FILE_PATH"
         echo "SERVICE_NAME: $SERVICE_NAME"
-        echo "IMAGE_TAG: $IMAGE_TAG"
         echo "SWARM_SERVICE_NAME: $SWARM_SERVICE_NAME"
+        echo "IMAGE_TAG: $IMAGE_TAG"
         
         if [ -n "$SWARM_SERVICE_NAME" ]; then
           # Update specific swarm service by service name

--- a/.github/workflows/cd-gitops.yml
+++ b/.github/workflows/cd-gitops.yml
@@ -27,6 +27,10 @@ on:
         required: true
         type: string
         description: The name of the service to update.
+      SWARM_SERVICE_NAME:
+        required: false
+        type: string
+        description: The specific swarm service name to update (e.g., us-west). If provided, only this service will be updated by service name rather than image name.
       RUNNER: 
         required: false
         type: string
@@ -80,6 +84,7 @@ jobs:
         GITOPS_REPOSITORY: ${{ inputs.GITOPS_REPOSITORY }}
         FILE_PATH: ${{ inputs.FILE_PATH }}
         SERVICE_NAME: ${{ inputs.SERVICE_NAME }}
+        SWARM_SERVICE_NAME: ${{ inputs.SWARM_SERVICE_NAME }}
         IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
         ORCHESTRATOR: ${{ inputs.ORCHESTRATOR }}
         BRANCH_NAME: ${{ inputs.BRANCH_NAME }}


### PR DESCRIPTION
Adds SWARM_SERVICE_NAME parameter to enable updating specific swarm services by service name rather than image name pattern. Maintains backward compatibility with existing SERVICE_NAME behavior.