### PR TITLE
Update cicd-docker-build-and-distribute.yml

### DIFF
--- a/.github/workflows/cicd-docker-build-and-distribute.yml
+++ b/.github/workflows/cicd-docker-build-and-distribute.yml
@@ -176,6 +176,7 @@ jobs:
           FILES: './${{ inputs.CODE_WORKING_DIRECTORY }}/*.tar.gz'
           EXEC_COMMANDS: 'echo "${{ github.sha }}" > ${{ inputs.META_FILE_PATH_PREFIX }}/hash.txt'
           FILES_FOLDER: ${{ inputs.META_FILE_PATH_PREFIX }}
+          TELEPORT_VERSION: '18.1.4'
         env:
           HOSTNAME: ${{ secrets.HOSTNAME }}
           PROXY_URL: ${{ secrets.PROXY_URL }}


### PR DESCRIPTION
Updates teleport version on CICD build phases. Linked to https://github.com/signalwire/cloud-product/issues/15908

This matches the agent version running on the machine target of the CI/CD phase that connects to it.