### PR TITLE
Fix Dasel validation

### DIFF
--- a/.github/actions/test-configs/action.yml
+++ b/.github/actions/test-configs/action.yml
@@ -10,13 +10,13 @@ runs:
       id: cache
       with:
         path: ./dasel
-        key: ${{ runner.os }}-dasel
+        key: ${{ runner.os }}-dasel-v2.8.1
         restore-keys: |
-          ${{ runner.os }}-dasel
-    
+          ${{ runner.os }}-dasel-v2.8.1
+
     - name: Install Dasel
       if: steps.cache.outputs.cache-hit != 'true'
-      run: curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
+      run: curl -sSLf https://github.com/TomWright/dasel/releases/download/v2.8.1/dasel_linux_amd64 -L -o dasel && chmod +x dasel
       shell: bash
 
     # Leave it static for now


### PR DESCRIPTION
## Description

Dasel validation is currently broken because latest version of Dasel got rid of `validate` command

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor
