### PR TITLE
Add Go support to ci-check.yml/ci.yml

### DIFF
--- a/.github/actions/test-go/action.yml
+++ b/.github/actions/test-go/action.yml
@@ -9,27 +9,38 @@ inputs:
   RUN_TESTS:
     required: false
     default: true
-    description: "Whenever you wanna run go test."
+    description: "Whether to run go test."
   RUN_LINT:
     required: false
     default: true
-    description: "Whenever you wanna run golangci-lint."
+    description: "Whether to run golangci-lint."
   RUN_VULNCHECK:
     required: false
     default: true
-    description: "Whenever you wanna run govulncheck."
+    description: "Whether to run govulncheck."
   GOLANGCI_LINT_VERSION:
     required: false
     default: "latest"
     description: "golangci-lint-action version pin."
+  GOVULNCHECK_VERSION:
+    required: false
+    default: "latest"
+    description: "govulncheck version to install (e.g. a pinned release instead of latest, for reproducible CI)."
 
 runs:
   using: "composite"
   steps:
-    - name: Setup Go
+    - name: Setup Go (pinned version)
+      if: ${{ inputs.GO_VERSION != '' }}
       uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.GO_VERSION }}
+        cache: true
+
+    - name: Setup Go (from go.mod)
+      if: ${{ inputs.GO_VERSION == '' }}
+      uses: actions/setup-go@v5
+      with:
         go-version-file: go.mod
         cache: true
 
@@ -44,7 +55,7 @@ runs:
     - name: Format check
       shell: bash
       run: |
-        UNFORMATTED=$(gofmt -l .)
+        UNFORMATTED=$(gofmt -l $(go list -f '{{.Dir}}' ./...))
         if [ -n "$UNFORMATTED" ]; then
           echo "The following files are not gofmt-formatted:"
           echo "$UNFORMATTED"
@@ -66,5 +77,5 @@ runs:
       if: ${{ inputs.RUN_VULNCHECK == 'true' || inputs.RUN_VULNCHECK == true }}
       shell: bash
       run: |
-        go install golang.org/x/vuln/cmd/govulncheck@latest
-        govulncheck ./...
+        go install golang.org/x/vuln/cmd/govulncheck@${{ inputs.GOVULNCHECK_VERSION }}
+        "$(go env GOPATH)/bin/govulncheck" ./...

--- a/.github/actions/test-go/action.yml
+++ b/.github/actions/test-go/action.yml
@@ -1,0 +1,70 @@
+name: Go Build & Test
+description: Go build, vet, format check, unit tests, lint, and vulnerability scan
+
+inputs:
+  GO_VERSION:
+    required: false
+    default: ""
+    description: "Go version to use. Defaults to the version in go.mod (go-version-file) if not set."
+  RUN_TESTS:
+    required: false
+    default: true
+    description: "Whenever you wanna run go test."
+  RUN_LINT:
+    required: false
+    default: true
+    description: "Whenever you wanna run golangci-lint."
+  RUN_VULNCHECK:
+    required: false
+    default: true
+    description: "Whenever you wanna run govulncheck."
+  GOLANGCI_LINT_VERSION:
+    required: false
+    default: "latest"
+    description: "golangci-lint-action version pin."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ inputs.GO_VERSION }}
+        go-version-file: go.mod
+        cache: true
+
+    - name: Build
+      shell: bash
+      run: go build ./...
+
+    - name: Vet
+      shell: bash
+      run: go vet ./...
+
+    - name: Format check
+      shell: bash
+      run: |
+        UNFORMATTED=$(gofmt -l .)
+        if [ -n "$UNFORMATTED" ]; then
+          echo "The following files are not gofmt-formatted:"
+          echo "$UNFORMATTED"
+          exit 1
+        fi
+
+    - name: Test
+      if: ${{ inputs.RUN_TESTS == 'true' || inputs.RUN_TESTS == true }}
+      shell: bash
+      run: go test ./... -race -coverprofile=coverage.out
+
+    - name: Lint
+      if: ${{ inputs.RUN_LINT == 'true' || inputs.RUN_LINT == true }}
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: ${{ inputs.GOLANGCI_LINT_VERSION }}
+
+    - name: Vulnerability scan
+      if: ${{ inputs.RUN_VULNCHECK == 'true' || inputs.RUN_VULNCHECK == true }}
+      shell: bash
+      run: |
+        go install golang.org/x/vuln/cmd/govulncheck@latest
+        govulncheck ./...

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -37,12 +37,12 @@ on:
         required: false
         type: boolean
         default: true
-        description: 'Whenever you wanna run golangci-lint (Go).'
+        description: 'Whether to run golangci-lint (Go).'
       RUN_VULNCHECK:
         required: false
         type: boolean
         default: true
-        description: 'Whenever you wanna run govulncheck (Go).'
+        description: 'Whether to run govulncheck (Go).'
       TEST_DEPENDENCIES:
         required: false
         type: boolean

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -29,6 +29,20 @@ on:
         required: false
         type: string
         description: Default Python version
+      GO_VERSION:
+        required: false
+        type: string
+        description: 'Go version to use. Defaults to the version in go.mod if not set.'
+      RUN_LINT:
+        required: false
+        type: boolean
+        default: true
+        description: 'Whenever you wanna run golangci-lint (Go).'
+      RUN_VULNCHECK:
+        required: false
+        type: boolean
+        default: true
+        description: 'Whenever you wanna run govulncheck (Go).'
       TEST_DEPENDENCIES:
         required: false
         type: boolean
@@ -228,6 +242,15 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
+    - name: Test Go
+      if: ${{ inputs.LANGUAGE == 'Go' }}
+      uses: ./actions/.github/actions/test-go
+      with:
+        GO_VERSION: ${{ inputs.GO_VERSION }}
+        RUN_TESTS: ${{ inputs.RUN_TESTS }}
+        RUN_LINT: ${{ inputs.RUN_LINT }}
+        RUN_VULNCHECK: ${{ inputs.RUN_VULNCHECK }}
+
     - name: Test configs
       if: inputs.LANGUAGE == 'configs' || inputs.LANGUAGE == 'configs'
       uses: ./actions/.github/actions/test-configs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,20 @@ on:
         required: false
         type: string
         default: "3.10"
+      GO_VERSION:
+        required: false
+        type: string
+        description: 'Go version to use. Defaults to the version in go.mod if not set.'
+      RUN_LINT:
+        required: false
+        type: boolean
+        default: true
+        description: 'Whenever you wanna run golangci-lint (Go).'
+      RUN_VULNCHECK:
+        required: false
+        type: boolean
+        default: true
+        description: 'Whenever you wanna run govulncheck (Go).'
       PUSH:
         required: false
         type: boolean
@@ -235,6 +249,9 @@ jobs:
       RUBY_VERSION: ${{ inputs.RUBY_VERSION }}
       DOTNET_VERSION: ${{ inputs.DOTNET_VERSION }}
       PYTHON_VERSION: ${{ inputs.PYTHON_VERSION }}
+      GO_VERSION: ${{ inputs.GO_VERSION }}
+      RUN_LINT: ${{ inputs.RUN_LINT }}
+      RUN_VULNCHECK: ${{ inputs.RUN_VULNCHECK }}
       TEST_DEPENDENCIES: ${{ inputs.TEST_DEPENDENCIES }}
       TEST_DEPENDENCIES_PRIVATE: ${{ inputs.TEST_DEPENDENCIES_PRIVATE }}
       DEPENDENCIES_FILE: ${{ inputs.DEPENDENCIES_FILE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ on:
         required: false
         type: boolean
         default: true
-        description: 'Whenever you wanna run golangci-lint (Go).'
+        description: 'Whether to run golangci-lint (Go).'
       RUN_VULNCHECK:
         required: false
         type: boolean
         default: true
-        description: 'Whenever you wanna run govulncheck (Go).'
+        description: 'Whether to run govulncheck (Go).'
       PUSH:
         required: false
         type: boolean


### PR DESCRIPTION
## Summary
Adds Go support to the reusable CI workflows, which had none (only .NET/JavaScript/Ruby/Python/configs) — needed for `signalwire/rtc-regions-synthetics`, a new Go service.

- New `test-go` composite action: `go build`, `go vet`, `gofmt -l` (fails on unformatted files), `go test -race -coverprofile`, `golangci-lint`, `govulncheck`.
- Wires `LANGUAGE: 'Go'` into `ci-check.yml` and passes `GO_VERSION`/`RUN_LINT`/`RUN_VULNCHECK` through `ci.yml`.
- SonarQube coverage step needed no changes — its non-`.NET` path already runs the generic `sonarqube-scan-action`, which is language-agnostic via `sonar-project.properties`.
- Real CD (Docker image build/push) is unaffected — `ci-build.yml`/the `docker` action are already language-agnostic.

## Test plan
- [x] YAML validated (`yaml.safe_load` on all three changed/added files)
- [x] `test-go`'s build/vet/fmt steps dogfooded locally against `rtc-regions-synthetics`
- [x] End-to-end validation via a real GitHub Actions run: `rtc-regions-synthetics`'s CI is temporarily pinned to this branch (`ci-check.yml@add-go-ci-support`) to confirm the composite action works on a real hosted runner before merge — will switch that pin to `@main` after this merges.

Tracked in signalwire/cloud-product#19692.