### PR TITLE
Fix golangci-lint-action Go 1.26 incompatibility

### DIFF
--- a/.github/actions/test-go/action.yml
+++ b/.github/actions/test-go/action.yml
@@ -69,7 +69,7 @@ runs:
 
     - name: Lint
       if: ${{ inputs.RUN_LINT == 'true' || inputs.RUN_LINT == true }}
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v9
       with:
         version: ${{ inputs.GOLANGCI_LINT_VERSION }}
 


### PR DESCRIPTION
## Summary
- `golangci-lint-action@v6` only resolves `version: latest` against v1.x golangci-lint releases. The newest of those (v1.64.8) is built with Go 1.24 and refuses to lint any module whose `go.mod` declares a newer `go` directive.
- Bumping to `golangci-lint-action@v9` resolves `latest` against the v2.x line, which tracks current Go toolchains and doesn't hit this ceiling.

## Test plan
- [ ] Confirm the `test-go` composite action lints successfully for a project declaring `go 1.26.0` once this merges