### PR TITLE
Add optional Go security-scan jobs and a reusable container build/sign workflow

### DIFF
--- a/.github/actions/gosec-scan/action.yml
+++ b/.github/actions/gosec-scan/action.yml
@@ -1,0 +1,25 @@
+name: Gosec Scan
+description: Run gosec (Go security static analysis) as a CI gate.
+
+inputs:
+  ARGS:
+    required: false
+    default: './...'
+    description: 'Arguments/package patterns passed to gosec.'
+  VERSION:
+    required: false
+    default: 'v2.25.0'
+    description: 'gosec version to install (e.g. a pinned release instead of latest, for reproducible CI).'
+
+runs:
+  using: "composite"
+  steps:
+    # `uses:` in a composite action step can't take an expression, so this is
+    # installed via `go install` (same pattern as govulncheck in test-go) rather
+    # than `uses: securego/gosec@${{ inputs.VERSION }}`, to keep VERSION an
+    # actual input instead of a hardcoded pin.
+    - name: Run Gosec Security Scanner
+      shell: bash
+      run: |
+        go install github.com/securego/gosec/v2/cmd/gosec@${{ inputs.VERSION }}
+        "$(go env GOPATH)/bin/gosec" ${{ inputs.ARGS }}

--- a/.github/actions/grype-scan/action.yml
+++ b/.github/actions/grype-scan/action.yml
@@ -1,0 +1,30 @@
+name: Grype Dependency Scan
+description: >-
+  Scan the filesystem for vulnerable dependencies with Grype as a CI gate.
+  Distinct from the anchore/ action, which scans a built container image and
+  files a GitHub issue rather than failing the job.
+
+inputs:
+  PATH:
+    required: false
+    default: '.'
+    description: 'Path to scan.'
+  SEVERITY_CUTOFF:
+    required: false
+    default: 'critical'
+    description: 'Minimum severity that fails the build (negligible, low, medium, high, critical).'
+  FAIL_BUILD:
+    required: false
+    default: 'true'
+    description: 'Whether to fail the job when a vulnerability at or above SEVERITY_CUTOFF is found.'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Scan dependencies with Grype
+      uses: anchore/scan-action@v7.4.0
+      with:
+        path: ${{ inputs.PATH }}
+        fail-build: ${{ inputs.FAIL_BUILD }}
+        severity-cutoff: ${{ inputs.SEVERITY_CUTOFF }}
+        output-format: table

--- a/.github/actions/semgrep-scan/action.yml
+++ b/.github/actions/semgrep-scan/action.yml
@@ -1,0 +1,23 @@
+name: Semgrep Scan
+description: Run Semgrep SAST as a CI gate.
+
+inputs:
+  CONFIG:
+    required: false
+    default: 'p/owasp-top-ten'
+    description: 'Semgrep config/ruleset to scan with (e.g. a p/ registry ruleset or a local path).'
+  VERSION:
+    required: false
+    default: ''
+    description: 'Pinned semgrep version (e.g. 1.90.0). Empty installs the latest release.'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Semgrep
+      shell: bash
+      run: python3 -m pip install --quiet --user "semgrep${{ inputs.VERSION != '' && format('=={0}', inputs.VERSION) || '' }}"
+
+    - name: Run Semgrep
+      shell: bash
+      run: python3 -m semgrep scan --config "${{ inputs.CONFIG }}" --error .

--- a/.github/actions/trivy-fs-scan/action.yml
+++ b/.github/actions/trivy-fs-scan/action.yml
@@ -1,0 +1,32 @@
+name: Trivy Filesystem Scan
+description: >-
+  Scan the filesystem for dependency and IaC vulnerabilities with Trivy as a CI
+  gate. Distinct from the trivy/ action, which scans a built container image
+  and files a GitHub issue rather than failing the job.
+
+inputs:
+  SCAN_REF:
+    required: false
+    default: '.'
+    description: 'Path to scan.'
+  SEVERITY:
+    required: false
+    default: 'CRITICAL,HIGH'
+    description: 'Comma-separated severities that fail the build.'
+  IGNORE_UNFIXED:
+    required: false
+    default: 'true'
+    description: 'Whether to ignore vulnerabilities with no available fix.'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run Trivy filesystem scanner
+      uses: aquasecurity/trivy-action@v0.36.0
+      with:
+        scan-type: fs
+        scan-ref: ${{ inputs.SCAN_REF }}
+        severity: ${{ inputs.SEVERITY }}
+        ignore-unfixed: ${{ inputs.IGNORE_UNFIXED }}
+        exit-code: '1'
+        format: table

--- a/.github/actions/trufflehog-scan/action.yml
+++ b/.github/actions/trufflehog-scan/action.yml
@@ -1,0 +1,18 @@
+name: TruffleHog Scan
+description: >-
+  Scan repository history for verified secrets as a CI gate. The calling job's
+  checkout step needs `fetch-depth: 0` for full-history scanning.
+
+inputs:
+  EXTRA_ARGS:
+    required: false
+    default: '--only-verified'
+    description: 'Extra arguments passed to trufflehog.'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Scan for secrets
+      uses: trufflesecurity/trufflehog@main
+      with:
+        extra_args: ${{ inputs.EXTRA_ARGS }}

--- a/.github/actions/trufflehog-scan/action.yml
+++ b/.github/actions/trufflehog-scan/action.yml
@@ -12,7 +12,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Pinned to a release tag (v3.95.8) rather than @main: a moving branch ref
+    # makes CI non-reproducible and lets upstream behavior change unreviewed.
     - name: Scan for secrets
-      uses: trufflesecurity/trufflehog@main
+      uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
       with:
         extra_args: ${{ inputs.EXTRA_ARGS }}

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -43,6 +43,31 @@ on:
         type: boolean
         default: true
         description: 'Whether to run govulncheck (Go).'
+      RUN_GOSEC:
+        required: false
+        type: boolean
+        default: false
+        description: 'Whether to run gosec (Go security static analysis) as a parallel gating job.'
+      RUN_SEMGREP:
+        required: false
+        type: boolean
+        default: false
+        description: 'Whether to run Semgrep SAST as a parallel gating job.'
+      RUN_TRUFFLEHOG:
+        required: false
+        type: boolean
+        default: false
+        description: 'Whether to run TruffleHog secret scanning as a parallel gating job.'
+      RUN_GRYPE:
+        required: false
+        type: boolean
+        default: false
+        description: 'Whether to run a Grype dependency vulnerability scan as a parallel gating job.'
+      RUN_TRIVY_FS:
+        required: false
+        type: boolean
+        default: false
+        description: 'Whether to run a Trivy filesystem (dependency + IaC) scan as a parallel gating job.'
       TEST_DEPENDENCIES:
         required: false
         type: boolean
@@ -265,3 +290,98 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
         SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
+
+  # ──────────────────────────────────────────────────────────────────
+  # Optional security-scan jobs, gated by RUN_* inputs (default off, so
+  # existing callers are unaffected). Run in parallel with `ci` rather than
+  # as steps inside it, since they're independent gates, not part of the
+  # build/test/lint sequence.
+  # ──────────────────────────────────────────────────────────────────
+  security-gosec:
+    name: gosec
+    if: ${{ inputs.RUN_GOSEC == true }}
+    runs-on: ${{ inputs.RUNNER }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        with:
+          repository: signalwire/actions-template
+          ref: main
+          path: actions
+
+      - uses: ./actions/.github/actions/gosec-scan
+
+  security-semgrep:
+    name: Semgrep SAST
+    if: ${{ inputs.RUN_SEMGREP == true }}
+    runs-on: ${{ inputs.RUNNER }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        with:
+          repository: signalwire/actions-template
+          ref: main
+          path: actions
+
+      - uses: ./actions/.github/actions/semgrep-scan
+
+  security-trufflehog:
+    name: TruffleHog secret scanning
+    if: ${{ inputs.RUN_TRUFFLEHOG == true }}
+    runs-on: ${{ inputs.RUNNER }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        with:
+          repository: signalwire/actions-template
+          ref: main
+          path: actions
+
+      - uses: ./actions/.github/actions/trufflehog-scan
+
+  security-grype:
+    name: Grype dependency scan
+    if: ${{ inputs.RUN_GRYPE == true }}
+    runs-on: ${{ inputs.RUNNER }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        with:
+          repository: signalwire/actions-template
+          ref: main
+          path: actions
+
+      - uses: ./actions/.github/actions/grype-scan
+
+  security-trivy-fs:
+    name: Trivy filesystem scan
+    if: ${{ inputs.RUN_TRIVY_FS == true }}
+    runs-on: ${{ inputs.RUNNER }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        with:
+          repository: signalwire/actions-template
+          ref: main
+          path: actions
+
+      - uses: ./actions/.github/actions/trivy-fs-scan

--- a/.github/workflows/container-build-sign.yml
+++ b/.github/workflows/container-build-sign.yml
@@ -1,0 +1,269 @@
+name: Container build, sign & SBOM
+
+# Reusable workflow: builds one Dockerfile against a list of services (matrix),
+# pushes each image to a GCP Artifact Registry repo via Workload Identity
+# Federation, then optionally scans/signs/attests them. Everything project-
+# specific is passed in via inputs — nothing here is hardcoded to a particular
+# GCP project, registry, or signing key.
+
+on:
+  workflow_call:
+    inputs:
+      IMAGE_REPO:
+        required: true
+        type: string
+        description: 'Artifact Registry repo, e.g. us-east1-docker.pkg.dev/<project>/<repo>.'
+      WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+        type: string
+        description: 'GCP Workload Identity Federation provider for google-github-actions/auth.'
+      PROJECT_ID:
+        required: true
+        type: string
+        description: 'GCP project id.'
+      SERVICES:
+        required: true
+        type: string
+        description: 'Space-separated service names. Each is built from DOCKERFILE with --build-arg SERVICE=<name> and pushed as IMAGE_REPO/<name>:tag.'
+      DOCKERFILE:
+        required: false
+        type: string
+        default: 'Dockerfile'
+        description: 'Dockerfile used to build every service in SERVICES.'
+      EXTRA_BUILD_ARGS:
+        required: false
+        type: string
+        default: ''
+        description: 'Extra --build-arg entries, one KEY=VALUE per line.'
+      PLATFORMS:
+        required: false
+        type: string
+        default: 'linux/amd64'
+      IMAGE_TAG:
+        required: false
+        type: string
+        default: ''
+        description: 'Explicit image tag. If empty: refs/tags/v* pushes use the tag without its v prefix, everything else uses the 12-char short SHA.'
+      ENABLE_TRIVY_IMAGE_SCAN:
+        required: false
+        type: boolean
+        default: true
+        description: 'Scan each pushed image with Trivy (CRITICAL/HIGH, ignore-unfixed) before signing.'
+      ENABLE_COSIGN_SIGN:
+        required: false
+        type: boolean
+        default: false
+        description: 'Sign each image (by digest) with Cosign using a GCP KMS key. Requires KMS_KEY_PATH.'
+      KMS_KEY_PATH:
+        required: false
+        type: string
+        default: ''
+        description: 'GCP KMS key resource path for Cosign signing (used as gcpkms://<path>). Required when ENABLE_COSIGN_SIGN is true.'
+      ENABLE_BINAUTHZ:
+        required: false
+        type: boolean
+        default: false
+        description: 'Create a Binary Authorization attestation per image after signing. Requires ENABLE_COSIGN_SIGN and BINAUTHZ_ATTESTOR.'
+      BINAUTHZ_ATTESTOR:
+        required: false
+        type: string
+        default: ''
+        description: 'Binary Authorization attestor name. Required when ENABLE_BINAUTHZ is true.'
+      ENABLE_SBOM:
+        required: false
+        type: boolean
+        default: false
+        description: 'Generate a Syft SPDX SBOM per image, attest it with Cosign, and upload all SBOMs as a workflow artifact. Requires ENABLE_COSIGN_SIGN.'
+
+jobs:
+  resolve:
+    name: Resolve service matrix
+    runs-on: ubuntu-latest
+    outputs:
+      services_json: ${{ steps.resolve.outputs.services_json }}
+      image_tag: ${{ steps.resolve.outputs.image_tag }}
+    steps:
+      - name: Resolve services list and image tag
+        id: resolve
+        run: |
+          echo "services_json=$(echo '${{ inputs.SERVICES }}' | jq -R -c 'split(" ") | map(select(length > 0))')" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${{ inputs.IMAGE_TAG }}" ]; then
+            echo "image_tag=${{ inputs.IMAGE_TAG }}" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "image_tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_tag=$(echo "${GITHUB_SHA}" | cut -c1-12)" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build — ${{ matrix.service }}
+    needs: [resolve]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJSON(needs.resolve.outputs.services_json) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ inputs.WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ inputs.PROJECT_ID }}
+
+      - uses: google-github-actions/setup-gcloud@v3.0.1
+
+      - name: Authenticate to Artifact Registry
+        run: gcloud auth configure-docker "$(echo '${{ inputs.IMAGE_REPO }}' | cut -d/ -f1)" --quiet
+
+      - name: Build & push ${{ matrix.service }}
+        env:
+          TAG: ${{ needs.resolve.outputs.image_tag }}
+          IMAGE_REPO: ${{ inputs.IMAGE_REPO }}
+          SVC: ${{ matrix.service }}
+          CACHE_REF: ${{ inputs.IMAGE_REPO }}/cache/${{ matrix.service }}
+          EXTRA_BUILD_ARGS: ${{ inputs.EXTRA_BUILD_ARGS }}
+        run: |
+          BUILD_ARGS=(--build-arg "SERVICE=${SVC}")
+          while IFS= read -r line; do
+            [ -n "$line" ] && BUILD_ARGS+=(--build-arg "$line")
+          done <<< "$EXTRA_BUILD_ARGS"
+
+          docker buildx build \
+            --platform "${{ inputs.PLATFORMS }}" \
+            "${BUILD_ARGS[@]}" \
+            --cache-from "type=registry,ref=${CACHE_REF}" \
+            --cache-to "type=registry,ref=${CACHE_REF},mode=max" \
+            -f "${{ inputs.DOCKERFILE }}" \
+            -t "${IMAGE_REPO}/${SVC}:${TAG}" \
+            --push \
+            .
+
+  sign-and-attest:
+    name: Scan, sign & attest images
+    needs: [resolve, build]
+    if: ${{ inputs.ENABLE_TRIVY_IMAGE_SCAN || inputs.ENABLE_COSIGN_SIGN }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ inputs.WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ inputs.PROJECT_ID }}
+
+      - uses: google-github-actions/setup-gcloud@v3.0.1
+        with:
+          install_components: beta
+
+      - name: Authenticate to Artifact Registry
+        run: gcloud auth configure-docker "$(echo '${{ inputs.IMAGE_REPO }}' | cut -d/ -f1)" --quiet
+
+      - name: Install Trivy
+        if: ${{ inputs.ENABLE_TRIVY_IMAGE_SCAN }}
+        uses: aquasecurity/setup-trivy@v0.3.1
+
+      - name: Trivy — scan each image
+        if: ${{ inputs.ENABLE_TRIVY_IMAGE_SCAN }}
+        env:
+          TAG: ${{ needs.resolve.outputs.image_tag }}
+          IMAGE_REPO: ${{ inputs.IMAGE_REPO }}
+          SERVICES: ${{ inputs.SERVICES }}
+        run: |
+          for svc in $SERVICES; do
+            echo "::group::Trivy — ${svc}"
+            trivy image \
+              --severity CRITICAL,HIGH \
+              --ignore-unfixed \
+              --exit-code 1 \
+              --format table \
+              "${IMAGE_REPO}/${svc}:${TAG}"
+            echo "::endgroup::"
+          done
+
+      - name: Install Cosign
+        if: ${{ inputs.ENABLE_COSIGN_SIGN }}
+        uses: sigstore/cosign-installer@v3
+
+      # RSA-PKCS1 KMS keys fail Rekor verification, so --tlog-upload is
+      # disabled — the registry plus GCP Cloud Audit Logs are the audit trail.
+      - name: Sign images
+        if: ${{ inputs.ENABLE_COSIGN_SIGN }}
+        env:
+          TAG: ${{ needs.resolve.outputs.image_tag }}
+          IMAGE_REPO: ${{ inputs.IMAGE_REPO }}
+          SERVICES: ${{ inputs.SERVICES }}
+          KMS_KEY_PATH: ${{ inputs.KMS_KEY_PATH }}
+        run: |
+          for svc in $SERVICES; do
+            IMAGE="${IMAGE_REPO}/${svc}:${TAG}"
+            DIGEST=$(gcloud artifacts docker images describe "${IMAGE}" --format='value(image_summary.digest)')
+            IMAGE_BY_DIGEST="${IMAGE_REPO}/${svc}@${DIGEST}"
+            cosign sign --key "gcpkms://${KMS_KEY_PATH}" --tlog-upload=false --yes "${IMAGE_BY_DIGEST}"
+          done
+
+      - name: Binary Authorization attestation
+        if: ${{ inputs.ENABLE_BINAUTHZ }}
+        env:
+          TAG: ${{ needs.resolve.outputs.image_tag }}
+          IMAGE_REPO: ${{ inputs.IMAGE_REPO }}
+          SERVICES: ${{ inputs.SERVICES }}
+          KMS_KEY_PATH: ${{ inputs.KMS_KEY_PATH }}
+          PROJECT_ID: ${{ inputs.PROJECT_ID }}
+          BINAUTHZ_ATTESTOR: ${{ inputs.BINAUTHZ_ATTESTOR }}
+        run: |
+          for svc in $SERVICES; do
+            IMAGE="${IMAGE_REPO}/${svc}:${TAG}"
+            DIGEST=$(gcloud artifacts docker images describe "${IMAGE}" --format='value(image_summary.digest)')
+            IMAGE_BY_DIGEST="${IMAGE_REPO}/${svc}@${DIGEST}"
+            gcloud beta container binauthz attestations sign-and-create \
+              --artifact-url="${IMAGE_BY_DIGEST}" \
+              --attestor="${BINAUTHZ_ATTESTOR}" \
+              --attestor-project="${PROJECT_ID}" \
+              --keyversion="${KMS_KEY_PATH}"
+          done
+
+      - name: Install Syft
+        if: ${{ inputs.ENABLE_SBOM }}
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Generate SBOM and attest per image
+        if: ${{ inputs.ENABLE_SBOM }}
+        env:
+          TAG: ${{ needs.resolve.outputs.image_tag }}
+          IMAGE_REPO: ${{ inputs.IMAGE_REPO }}
+          SERVICES: ${{ inputs.SERVICES }}
+          KMS_KEY_PATH: ${{ inputs.KMS_KEY_PATH }}
+        run: |
+          for svc in $SERVICES; do
+            IMAGE="${IMAGE_REPO}/${svc}:${TAG}"
+            DIGEST=$(gcloud artifacts docker images describe "${IMAGE}" --format='value(image_summary.digest)')
+            IMAGE_BY_DIGEST="${IMAGE_REPO}/${svc}@${DIGEST}"
+            syft "${IMAGE_BY_DIGEST}" -o spdx-json > "sbom-${svc}.spdx.json"
+            cosign attest \
+              --key "gcpkms://${KMS_KEY_PATH}" \
+              --tlog-upload=false \
+              --yes \
+              --type spdxjson \
+              --predicate "sbom-${svc}.spdx.json" \
+              "${IMAGE_BY_DIGEST}"
+          done
+
+      - name: Upload SBOM artifacts
+        if: ${{ inputs.ENABLE_SBOM }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-spdx-${{ github.run_id }}
+          path: sbom-*.spdx.json
+          if-no-files-found: error

--- a/.github/workflows/container-build-sign.yml
+++ b/.github/workflows/container-build-sign.yml
@@ -83,6 +83,29 @@ jobs:
       services_json: ${{ steps.resolve.outputs.services_json }}
       image_tag: ${{ steps.resolve.outputs.image_tag }}
     steps:
+      - name: Validate signing/attestation/SBOM inputs
+        run: |
+          fail=0
+          if [ "${{ inputs.ENABLE_COSIGN_SIGN }}" = "true" ] && [ -z "${{ inputs.KMS_KEY_PATH }}" ]; then
+            echo "::error::ENABLE_COSIGN_SIGN is true but KMS_KEY_PATH is empty."
+            fail=1
+          fi
+          if [ "${{ inputs.ENABLE_BINAUTHZ }}" = "true" ]; then
+            if [ "${{ inputs.ENABLE_COSIGN_SIGN }}" != "true" ]; then
+              echo "::error::ENABLE_BINAUTHZ requires ENABLE_COSIGN_SIGN to also be true."
+              fail=1
+            fi
+            if [ -z "${{ inputs.BINAUTHZ_ATTESTOR }}" ]; then
+              echo "::error::ENABLE_BINAUTHZ is true but BINAUTHZ_ATTESTOR is empty."
+              fail=1
+            fi
+          fi
+          if [ "${{ inputs.ENABLE_SBOM }}" = "true" ] && [ "${{ inputs.ENABLE_COSIGN_SIGN }}" != "true" ]; then
+            echo "::error::ENABLE_SBOM requires ENABLE_COSIGN_SIGN to also be true (SBOMs are attested with Cosign)."
+            fail=1
+          fi
+          exit "$fail"
+
       - name: Resolve services list and image tag
         id: resolve
         run: |


### PR DESCRIPTION
## Summary

- `ci-check.yml` gains four optional, parallel security-scan jobs for Go
  (and, where applicable, language-agnostic) projects: gosec, Semgrep SAST,
  TruffleHog secret scanning, and a Grype dependency scan, plus a Trivy
  filesystem scan. Each is gated by its own boolean input
  (`RUN_GOSEC`/`RUN_SEMGREP`/`RUN_TRUFFLEHOG`/`RUN_GRYPE`/`RUN_TRIVY_FS`),
  all defaulting to `false` so existing callers see no behavior change.
- Each scan is a new standalone composite action under `.github/actions/`
  (`gosec-scan`, `semgrep-scan`, `trufflehog-scan`, `grype-scan`,
  `trivy-fs-scan`) — separate from the existing `trivy/`/`anchore/` actions,
  which scan a built image and file a GitHub issue rather than gating a job.
- New reusable workflow `container-build-sign.yml`: builds one Dockerfile
  against a list of services (matrix), pushes each to a GCP Artifact
  Registry repo via Workload Identity Federation, then optionally
  Trivy-scans, Cosign-signs (GCP KMS), Binary Authorization-attests, and
  generates a Syft SBOM per image. Every project-specific value (registry,
  WIF provider, KMS key, attestor, service list) is a workflow input —
  nothing is hardcoded.

## Test plan

- [x] `actionlint` passes clean on both modified/added workflow files
      (pre-existing lint findings elsewhere in the repo are unrelated to
      this change).
- [ ] A consuming repo opts into one or more `RUN_*` flags on `ci-check.yml`
      and confirms the corresponding job runs and gates the check.
- [ ] A consuming repo calls `container-build-sign.yml` end-to-end against
      a real Artifact Registry repo and WIF provider.