### PR TITLE
Fix semgrep-scan: invoke the semgrep binary directly

### DIFF
--- a/.github/actions/semgrep-scan/action.yml
+++ b/.github/actions/semgrep-scan/action.yml
@@ -16,8 +16,10 @@ runs:
   steps:
     - name: Install Semgrep
       shell: bash
-      run: python3 -m pip install --quiet --user "semgrep${{ inputs.VERSION != '' && format('=={0}', inputs.VERSION) || '' }}"
+      run: |
+        python3 -m pip install --quiet --user "semgrep${{ inputs.VERSION != '' && format('=={0}', inputs.VERSION) || '' }}"
+        echo "$(python3 -m site --user-base)/bin" >> "$GITHUB_PATH"
 
     - name: Run Semgrep
       shell: bash
-      run: python3 -m semgrep scan --config "${{ inputs.CONFIG }}" --error .
+      run: semgrep scan --config "${{ inputs.CONFIG }}" --error .


### PR DESCRIPTION
## Summary

- `semgrep-scan` (added in #416) invoked `python -m semgrep`, which has been
  deprecated since semgrep 1.38.0 and exits nonzero immediately, before any
  rules run. Every call failed regardless of actual findings.
- Fix: add the `pip --user` install location to `PATH` and call the
  `semgrep` binary directly.

## Test plan

- [x] Verified locally: installed semgrep via `pip install --user`, ran
      `semgrep scan --config p/owasp-top-ten --error .` directly — exits 0
      with real rule output, vs. the old invocation's immediate exit 2.
- [x] Confirmed via a live consumer run (rtc-regions-synthetics) that the old
      invocation failed this way in practice.