### PR TITLE
Add GCP Artifact Registry support to ci-build

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -90,29 +90,41 @@ runs:
         version: latest
         endpoint: builders
 
+    # DockerHub: IMAGE_REPO/PROJECT_NAME
+    # Custom (e.g. Artifact Registry): REGISTRY/IMAGE_REPO/PROJECT_NAME
+    - name: Resolve image name
+      id: image
+      shell: bash
+      run: |
+        REGISTRY="${{ inputs.REGISTRY }}"
+        IMAGE_REPO="${{ inputs.IMAGE_REPO }}"
+        PROJECT_NAME="${{ inputs.PROJECT_NAME }}"
+        if [ -z "$REGISTRY" ] || [ "$REGISTRY" = "registry.hub.docker.com" ] || [ "$REGISTRY" = "docker.io" ]; then
+          echo "name=${IMAGE_REPO}/${PROJECT_NAME}" >> "$GITHUB_OUTPUT"
+        else
+          echo "name=${REGISTRY}/${IMAGE_REPO}/${PROJECT_NAME}" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5
       with:
-        # list of Docker images to use as base name for tags
         images: |
-          signalwire/${{ inputs.PROJECT_NAME }}
-        # generate Docker tags based on the following events/attributes
+          ${{ steps.image.outputs.name }}
         tags: |
           ${{ inputs.TAG }}
-    
-    # - name: Login to ${{ inputs.REGISTRY }}
-    #   uses: docker/login-action@v2
-    #   if: contains(inputs.REGISTRY, 'pkg.dev' )
-    #   with:
-    #     registry: ${{ inputs.REGISTRY }}
-    #     username: 'oauth2accesstoken'
-    #     password: ${{ env.GCLOUD_ACCESS_TOKEN }}
+
+    - name: Login to Artifact Registry
+      uses: docker/login-action@v3
+      if: contains(inputs.REGISTRY, 'pkg.dev') && inputs.TAG_ONLY == 'false'
+      with:
+        registry: ${{ inputs.REGISTRY }}
+        username: oauth2accesstoken
+        password: ${{ env.GCLOUD_ACCESS_TOKEN }}
 
     - name: Login to DockerHub
       uses: docker/login-action@v3
-      if: inputs.TAG_ONLY == 'false'
-      # if: contains(inputs.REGISTRY, 'docker.com' )
+      if: ${{ !contains(inputs.REGISTRY, 'pkg.dev') && inputs.TAG_ONLY == 'false' }}
       with:
         username: ${{ env.DOCKERHUB_USERNAME }}
         password: ${{ env.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -60,6 +60,7 @@ on:
         type: string
         required: false
         default: registry.hub.docker.com
+        description: 'Registry host. Use us-east1-docker.pkg.dev (or similar) for GCP Artifact Registry.'
       TOKEN_FORMAT:
         type: string
         default: id_token
@@ -68,7 +69,17 @@ on:
         type: string
         required: false
         default: 'signalwire'
-        description: 'The default registry repo owner.'
+        description: 'Registry repo owner/path. For Artifact Registry: <project>/<repo>.'
+      WORKLOAD_IDENTITY_PROVIDER:
+        type: string
+        required: false
+        default: ''
+        description: 'GCP Workload Identity Federation provider. Required when REGISTRY contains pkg.dev.'
+      PROJECT_ID:
+        type: string
+        required: false
+        default: ''
+        description: 'GCP project id. Required when REGISTRY contains pkg.dev.'
       CONTAINER_SCAN:
         type: boolean
         default: true
@@ -242,17 +253,28 @@ jobs:
       env:
         PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-    # Remove unitil use it
-    # - uses: ./actions/.github/actions/gcloud-auth
-    #   if: contains(${{inputs.REGISTRY}}, 'pkg.dev' )
-    #   id: gcloud_auth
-    #   name: 'Authenticate to Googl Cloud'
-    #   with:
-    #     AUDIENCE: ${{ inputs.AUDIENCE }}
-    #     TOKEN_FORMAT: ${{ inputs.TOKEN_FORMAT }}
-    #   env:
-    #     GCP_WIP: ${{ secrets.GCP_WIP }}
-    #     GCP_SA: ${{ secrets.GCP_SA }}
+    - name: Validate Artifact Registry inputs
+      if: contains(inputs.REGISTRY, 'pkg.dev')
+      run: |
+        fail=0
+        if [ -z "${{ inputs.WORKLOAD_IDENTITY_PROVIDER }}" ]; then
+          echo "::error::REGISTRY is a GCP Artifact Registry (pkg.dev) but WORKLOAD_IDENTITY_PROVIDER is empty."
+          fail=1
+        fi
+        if [ -z "${{ inputs.PROJECT_ID }}" ]; then
+          echo "::error::REGISTRY is a GCP Artifact Registry (pkg.dev) but PROJECT_ID is empty."
+          fail=1
+        fi
+        exit "$fail"
+
+    - name: Authenticate to Google Cloud (WIF)
+      if: contains(inputs.REGISTRY, 'pkg.dev')
+      id: gcloud_auth
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ inputs.WORKLOAD_IDENTITY_PROVIDER }}
+        project_id: ${{ inputs.PROJECT_ID }}
+        token_format: access_token
 
     - name: Retrieve Secrets from HashiCorp Vault
       uses: ./actions/.github/actions/vault-secrets
@@ -288,10 +310,10 @@ jobs:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         DOCKER_SECRETS: ${{ secrets.DOCKER_SECRETS }}
+        GCLOUD_ACCESS_TOKEN: ${{ steps.gcloud_auth.outputs.access_token }}
         BUILD_ARGS: |
           ${{ secrets.BUILD_ARGS }}
-          ${{ inputs.BUILD_ARGS }}
-        # GCLOUD_ACCESS_TOKEN: ${{ steps.gcloud_auth.outputs.GCLOUD_TOKEN }}    
+          ${{ inputs.BUILD_ARGS }}    
     
     - uses: cloudposse/github-action-matrix-outputs-write@main
       id: out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,26 @@ on:
         default: false
         description: 'Whether to use cache when building the image'
         required: false
+      REGISTRY:
+        type: string
+        required: false
+        default: registry.hub.docker.com
+        description: 'Registry host. Use us-east1-docker.pkg.dev (or similar) for GCP Artifact Registry.'
+      IMAGE_REPO:
+        type: string
+        required: false
+        default: 'signalwire'
+        description: 'Registry repo owner/path. For Artifact Registry: <project>/<repo>.'
+      WORKLOAD_IDENTITY_PROVIDER:
+        type: string
+        required: false
+        default: ''
+        description: 'GCP Workload Identity Federation provider. Required when REGISTRY contains pkg.dev.'
+      PROJECT_ID:
+        type: string
+        required: false
+        default: ''
+        description: 'GCP project id. Required when REGISTRY contains pkg.dev.'
       ## Vault Secrets
       VAULT_SECRETS:
         type: string
@@ -207,9 +227,11 @@ on:
       SONAR_PROJECT_KEY: 
         required: false
       DOCKERHUB_USERNAME:
-        required: true
+        required: false
+        description: 'DockerHub username. Required when REGISTRY is DockerHub.'
       DOCKERHUB_TOKEN:
-        required: true
+        required: false
+        description: 'DockerHub PAT. Required when REGISTRY is DockerHub.'
       GPG_PASSPHRASE:
         required: false
       GH_BOT_DEPLOY_KEY:
@@ -308,6 +330,10 @@ jobs:
       TELEPORT_APP: ${{ inputs.TELEPORT_APP }}
       TELEPORT_PROXY_URL: ${{ inputs.TELEPORT_PROXY_URL }}
       ENABLE_DOCKER_BUILD_CACHE: ${{ inputs.ENABLE_DOCKER_BUILD_CACHE }}
+      REGISTRY: ${{ inputs.REGISTRY }}
+      IMAGE_REPO: ${{ inputs.IMAGE_REPO }}
+      WORKLOAD_IDENTITY_PROVIDER: ${{ inputs.WORKLOAD_IDENTITY_PROVIDER }}
+      PROJECT_ID: ${{ inputs.PROJECT_ID }}
     secrets:
       GH_BOT_DEPLOY_KEY: ${{ secrets.GH_BOT_DEPLOY_KEY }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Summary
- Wire `REGISTRY` / `IMAGE_REPO` into Docker image names (DockerHub stays `owner/image`; Artifact Registry uses `host/project/repo/image`).
- Authenticate to `pkg.dev` registries via Workload Identity Federation (`WORKLOAD_IDENTITY_PROVIDER` + `PROJECT_ID`) and `docker/login-action` with `oauth2accesstoken`.
- Expose the new inputs on `ci.yml` and make DockerHub secrets optional so GCP-only callers work without them.

## Test plan
- [ ] Existing DockerHub callers still build/push with default `REGISTRY` / `IMAGE_REPO` (no behavior change).
- [ ] Call `ci-build` with `REGISTRY: us-east1-docker.pkg.dev`, `IMAGE_REPO: <project>/<repo>`, WIF inputs, and `PUSH: true`; confirm image lands in Artifact Registry.
- [ ] Call with `pkg.dev` but missing `WORKLOAD_IDENTITY_PROVIDER` or `PROJECT_ID`; confirm fail-fast validation errors.
- [ ] Call `ci.yml` for a GCP-only project without `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`; confirm the workflow is accepted.


Made with [Cursor](https://cursor.com)