### PR TITLE
Add formatted Go test report via dorny/test-reporter

### DIFF
--- a/.github/actions/test-go/action.yml
+++ b/.github/actions/test-go/action.yml
@@ -65,7 +65,16 @@ runs:
     - name: Test
       if: ${{ inputs.RUN_TESTS == 'true' || inputs.RUN_TESTS == true }}
       shell: bash
-      run: go test ./... -race -coverprofile=coverage.out
+      run: go test -json ./... -race -coverprofile=coverage.out > test-results.json || true
+
+    - name: Test Report
+      uses: dorny/test-reporter@v2
+      if: always() && (inputs.RUN_TESTS == 'true' || inputs.RUN_TESTS == true)
+      with:
+        name: Go Tests
+        path: test-results.json
+        reporter: golang-json
+        fail-on-error: true
 
     - name: Lint
       if: ${{ inputs.RUN_LINT == 'true' || inputs.RUN_LINT == true }}


### PR DESCRIPTION
## Summary
- `test-go`'s Test step now runs `go test -json ./... -race -coverprofile=coverage.out`, writing results to `test-results.json`
- Added a `dorny/test-reporter@v2` step (`reporter: golang-json`) so Go CI runs get the same formatted pass/fail report on the GHA checks page/summary that `test-dotnet` and `test-javascript` already have — no extra JUnit-conversion tool needed since Go's native `-json` output is supported directly
- The `Test` step now `|| true`s so build/report/lint/vulncheck still run on test failure, with `fail-on-error: true` on the report step responsible for failing the job overall (same pattern as the existing dotnet/JS actions)

Closes signalwire/cloud-product#19708 (follow-up to signalwire/cloud-product#19692, which added Go support to this template).

Note: `dorny/test-reporter` needs `checks: write` on the calling workflow's token to publish the report. `ci-check.yml` doesn't set an explicit `permissions:` block (same as the existing dotnet/JS usages), so it inherits whatever the caller repo/org grants — if the report doesn't show up for a given repo, that's the first thing to check.

## Test plan
- [ ] Confirm `test-go/action.yml` parses (validated locally with `yaml.safe_load`)
- [ ] Run a workflow consuming `ci-check.yml` with `LANGUAGE: Go` and confirm the "Go Tests" check run/summary renders with per-test results
- [ ] Confirm a deliberately failing test still fails the job (via `fail-on-error`) and shows up in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)