### PR TITLE
Add a reusable release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,45 @@
+# Reusable workflow: runs release-please on push to the target branch,
+# authenticated via a GitHub App token rather than the default GITHUB_TOKEN
+# so the tag/release it creates can actually trigger other workflows (a
+# plain GITHUB_TOKEN's actions are excluded from re-triggering workflow
+# runs, GitHub's own recursion guard).
+
+name: Release Please
+
+on:
+  workflow_call:
+    inputs:
+      RELEASE_TYPE:
+        required: false
+        type: string
+        default: simple
+        description: 'release-please release-type, e.g. simple, go, node.'
+      APP_ID:
+        required: true
+        type: string
+        description: 'GitHub App ID used to mint the token release-please authenticates with. Not secret (the App still needs to be installed with access to the calling repo).'
+    secrets:
+      APP_PRIVATE_KEY:
+        required: true
+        description: 'Private key for APP_ID.'
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ inputs.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@v5
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          release-type: ${{ inputs.RELEASE_TYPE }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,8 @@
-# Reusable workflow: runs release-please on push to the target branch,
-# authenticated via a GitHub App token rather than the default GITHUB_TOKEN
-# so the tag/release it creates can actually trigger other workflows (a
-# plain GITHUB_TOKEN's actions are excluded from re-triggering workflow
-# runs, GitHub's own recursion guard).
+# Reusable workflow: runs release-please, authenticated via a GitHub App
+# token rather than the default GITHUB_TOKEN so the tag/release it creates
+# can actually trigger other workflows (a plain GITHUB_TOKEN's actions are
+# excluded from re-triggering workflow runs, GitHub's own recursion guard).
+# Callers typically invoke this on push to their release branch.
 
 name: Release Please
 
@@ -23,10 +23,7 @@ on:
         required: true
         description: 'Private key for APP_ID.'
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: {}
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary
- Adds a `workflow_call` reusable workflow wrapping release-please (GitHub App token, not the default GITHUB_TOKEN, so the release it creates can trigger other workflows), same shape as `ci-check.yml`/`ci-build.yml`.
- sip-operator and terraform-modules each maintain their own copy of this today, and have already drifted (different release-please-action versions, one authenticating with a stale PAT instead of a GitHub App token). This gives new consumers a single place to call instead of copy-pasting the steps again.
- `APP_ID` is a plain input, not a secret (it's a public app-id number, confirmed stored as a repo variable rather than a secret in terraform-modules); `APP_PRIVATE_KEY` is the actual secret.

## Test plan
- [ ] Consumed by `rtc-regions-synthetics`'s own `release-please.yml` (branch `chore/docker-release-pipeline`, not yet merged) once this lands
- [ ] YAML validated locally (`yaml.safe_load`)