### PR TITLE
Fix test-go's dorny/test-reporter to actually create a check run

### DIFF
--- a/.github/actions/test-go/action.yml
+++ b/.github/actions/test-go/action.yml
@@ -75,6 +75,11 @@ runs:
         path: test-results.json
         reporter: golang-json
         fail-on-error: true
+        # v2 defaults to true, which only writes a Job Summary entry and
+        # never calls the Checks API - no check run is created at all in
+        # that mode. False matches test-dotnet/test-javascript's existing
+        # dorny/test-reporter@v1 behavior (always creates a real check run).
+        use-actions-summary: false
 
     - name: Lint
       if: ${{ inputs.RUN_LINT == 'true' || inputs.RUN_LINT == true }}


### PR DESCRIPTION
## Summary
- `dorny/test-reporter@v2` defaults `use-actions-summary` to `true`, which only writes a Job Summary entry and never calls the Checks API at all - no "Go Tests" check run is created, despite the step completing successfully with no visible error.
- Confirmed at the source (`createReport()` in `dorny/test-reporter`): the `octokit.rest.checks.create()`/`.update()` calls live exclusively in the `else` branch of `if (this.useActionsSummary)`. Cross-checked with a debug-logged CI run on a real consumer (`rtc-regions-synthetics`): zero HTTP request/response debug lines around the Test Report step, versus full debug output on adjacent steps that do make API calls.
- `test-dotnet`/`test-javascript` use `dorny/test-reporter@v1`, which predates this input entirely and always creates a real check run - this is why their reports show up as distinct checks and Go's (added in #419) never did.
- Sets `use-actions-summary: false` so Go gets the same real check-run behavior as the other two languages.

Related to #419.

## Test plan
- [ ] Consuming repo (`rtc-regions-synthetics`) re-runs CI against this branch and confirms a "Go Tests" check run now appears on the commit (not just in this PR's own description)
- [ ] YAML validated locally (`yaml.safe_load`)