### PR TITLE
Skip redundant load-build when its output can never be tested

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -124,7 +124,7 @@ runs:
 
     - name: Build and export to Docker without cache
       uses: docker/build-push-action@v6
-      if: inputs.ENABLE_CACHE == 'false'
+      if: inputs.ENABLE_CACHE == 'false' && (inputs.PUSH == 'false' || (github.event_name == 'pull_request' && inputs.CONTAINER_TEST == 'true' && inputs.TAG_ONLY == 'false'))
       with:
         load: true
         tags: |
@@ -139,7 +139,7 @@ runs:
 
     - name: Build and export to Docker with cache
       uses: docker/build-push-action@v6
-      if: inputs.ENABLE_CACHE == 'true'
+      if: inputs.ENABLE_CACHE == 'true' && (inputs.PUSH == 'false' || (github.event_name == 'pull_request' && inputs.CONTAINER_TEST == 'true' && inputs.TAG_ONLY == 'false'))
       with:
         load: true
         tags: |


### PR DESCRIPTION
## Summary
- The `docker` composite action's "Build and export to Docker" step (`load: true`) runs unconditionally whenever `ENABLE_CACHE` matches, regardless of whether anything downstream will actually use the resulting local image.
- Its only consumer is the `Test` step, gated by `github.event_name == 'pull_request' && inputs.CONTAINER_TEST == 'true' && inputs.TAG_ONLY == 'false'` - a condition hardcoded in this action, not overridable by callers.
- So on any push-triggered build (or a PR build that doesn't opt into `CONTAINER_TEST`), the load-build produces an image nobody inspects, and then - if `PUSH` is true - a second, fully separate `docker/build-push-action` invocation builds the exact same Dockerfile again just to publish it. That's a full duplicate build cycle for no reason.
- Fix: add a complementary condition to both "Build and export to Docker" steps - only run when `PUSH == 'false'` (a build is still needed to validate the Dockerfile even without testing/pushing) OR the `Test` step's own condition holds (the loaded image is actually needed). This is logically `NOT(PUSH) OR <Test's condition>`, so it can never skip a build that would otherwise be tested - only ones whose output was already provably unused.

## Safety
Audited every real consumer across the org that calls `ci-build.yml`/`ci.yml` or the `docker` action directly (34 repos). Every single one falls into one of:
- `CONTAINER_TEST` explicitly `false` (majority) - unaffected, no test ever ran.
- `PUSH` can only be `true` on non-`pull_request` events (workflow trigger/job-level gating) - Test's condition was already structurally false there, so nothing changes.
- `CONTAINER_TEST` left at default `true` with a `pull_request` trigger present - confirmed the new condition still runs the load-build on PR events (preserving Test), and only skips it on push events where Test never ran anyway.

No consumer sets `TAG_ONLY`, and `ci-build.yml` doesn't even expose it as a pass-through input, so it's always `'false'` in practice.

## Test plan
- [x] YAML parses correctly, both new `if:` expressions manually traced for every real consumer's actual PUSH/CONTAINER_TEST/event combination
- [x] Confirmed the change is a strict logical refinement (`NOT(PUSH) OR <Test's existing condition>`) rather than a new heuristic - can't skip a build the Test step would have used
- [ ] Would appreciate a maintainer sanity-check given this is a shared action, before merging