### PR TITLE
feat: Add reusable workflows for Go DB-backed tests, Helm OCI push, and GitOps value bumps

### DIFF
--- a/.github/workflows/container-build-sign.yml
+++ b/.github/workflows/container-build-sign.yml
@@ -44,6 +44,11 @@ on:
         type: string
         default: ''
         description: 'Explicit image tag. If empty: refs/tags/v* pushes use the tag without its v prefix, everything else uses the 12-char short SHA.'
+      PUSH_IMAGES:
+        required: false
+        type: boolean
+        default: true
+        description: 'Push built images to IMAGE_REPO. When false, images are built and loaded locally only (e.g. PR validation) — scan/sign/SBOM steps are skipped since there is nothing in the registry to act on.'
       ENABLE_TRIVY_IMAGE_SCAN:
         required: false
         type: boolean
@@ -153,26 +158,33 @@ jobs:
           SVC: ${{ matrix.service }}
           CACHE_REF: ${{ inputs.IMAGE_REPO }}/cache/${{ matrix.service }}
           EXTRA_BUILD_ARGS: ${{ inputs.EXTRA_BUILD_ARGS }}
+          PUSH_IMAGES: ${{ inputs.PUSH_IMAGES }}
         run: |
           BUILD_ARGS=(--build-arg "SERVICE=${SVC}")
           while IFS= read -r line; do
             [ -n "$line" ] && BUILD_ARGS+=(--build-arg "$line")
           done <<< "$EXTRA_BUILD_ARGS"
 
+          OUTPUT_ARGS=(--load)
+          CACHE_ARGS=(--cache-from "type=registry,ref=${CACHE_REF}")
+          if [ "${PUSH_IMAGES}" = "true" ]; then
+            OUTPUT_ARGS=(--push)
+            CACHE_ARGS+=(--cache-to "type=registry,ref=${CACHE_REF},mode=max")
+          fi
+
           docker buildx build \
             --platform "${{ inputs.PLATFORMS }}" \
             "${BUILD_ARGS[@]}" \
-            --cache-from "type=registry,ref=${CACHE_REF}" \
-            --cache-to "type=registry,ref=${CACHE_REF},mode=max" \
+            "${CACHE_ARGS[@]}" \
             -f "${{ inputs.DOCKERFILE }}" \
             -t "${IMAGE_REPO}/${SVC}:${TAG}" \
-            --push \
+            "${OUTPUT_ARGS[@]}" \
             .
 
   sign-and-attest:
     name: Scan, sign & attest images
     needs: [resolve, build]
-    if: ${{ inputs.ENABLE_TRIVY_IMAGE_SCAN || inputs.ENABLE_COSIGN_SIGN }}
+    if: ${{ inputs.PUSH_IMAGES && (inputs.ENABLE_TRIVY_IMAGE_SCAN || inputs.ENABLE_COSIGN_SIGN) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/container-build-sign.yml
+++ b/.github/workflows/container-build-sign.yml
@@ -109,6 +109,12 @@ jobs:
             echo "::error::ENABLE_SBOM requires ENABLE_COSIGN_SIGN to also be true (SBOMs are attested with Cosign)."
             fail=1
           fi
+          # docker buildx build --load (used when PUSH_IMAGES is false) can't load a
+          # multi-platform manifest into the local Docker engine.
+          if [ "${{ inputs.PUSH_IMAGES }}" != "true" ] && [[ "${{ inputs.PLATFORMS }}" == *,* ]]; then
+            echo "::error::PUSH_IMAGES is false but PLATFORMS ('${{ inputs.PLATFORMS }}') lists more than one platform — buildx --load doesn't support multi-platform images. Set PUSH_IMAGES: true or use a single platform."
+            fail=1
+          fi
           exit "$fail"
 
       - name: Resolve services list and image tag
@@ -136,12 +142,12 @@ jobs:
       matrix:
         service: ${{ fromJSON(needs.resolve.outputs.services_json) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Authenticate to Google Cloud (WIF)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ inputs.WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ inputs.PROJECT_ID }}
@@ -190,10 +196,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Authenticate to Google Cloud (WIF)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ inputs.WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ inputs.PROJECT_ID }}
@@ -297,7 +303,7 @@ jobs:
 
       - name: Upload SBOM artifacts
         if: ${{ inputs.ENABLE_SBOM }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sbom-spdx-${{ github.run_id }}
           path: sbom-*.spdx.json

--- a/.github/workflows/gitops-values-bump.yml
+++ b/.github/workflows/gitops-values-bump.yml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.MODE == 'direct-commit' && inputs.TARGET_BRANCH || github.ref }}
+          ref: ${{ inputs.TARGET_BRANCH }}
 
       - name: Bump value
         env:

--- a/.github/workflows/gitops-values-bump.yml
+++ b/.github/workflows/gitops-values-bump.yml
@@ -1,0 +1,135 @@
+name: GitOps values bump
+
+# Reusable workflow: bumps an image tag in a Helm values file, either committing
+# directly to a branch (e.g. auto-deploy to dev) or opening a review PR (e.g.
+# gated production release). ArgoCD (or equivalent) picks up the change on sync.
+
+on:
+  workflow_call:
+    inputs:
+      VALUES_FILE:
+        required: true
+        type: string
+        description: 'Path to the values YAML file to update.'
+      YQ_PATH:
+        required: true
+        type: string
+        description: 'yq path to the tag field, e.g. .platformImage.tag'
+      IMAGE_TAG:
+        required: true
+        type: string
+      MODE:
+        required: true
+        type: string
+        description: 'direct-commit or pull-request'
+      TARGET_BRANCH:
+        required: true
+        type: string
+        description: 'Branch to commit to (direct-commit) or PR base branch (pull-request).'
+      PR_BRANCH_PREFIX:
+        required: false
+        type: string
+        default: 'release/'
+      PR_TITLE:
+        required: false
+        type: string
+        default: ''
+        description: 'Defaults to "Release <IMAGE_TAG> to <TARGET_BRANCH>" if empty.'
+      PR_BODY:
+        required: false
+        type: string
+        default: ''
+        description: 'Defaults to a standard review checklist if empty.'
+      COMMIT_MESSAGE:
+        required: false
+        type: string
+        default: ''
+        description: 'Defaults to "chore: update image tag to <IMAGE_TAG> [skip ci]" if empty.'
+
+jobs:
+  bump:
+    name: Bump ${{ inputs.YQ_PATH }} -> ${{ inputs.IMAGE_TAG }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Validate mode
+        run: |
+          case "${{ inputs.MODE }}" in
+            direct-commit|pull-request) ;;
+            *)
+              echo "::error::MODE must be direct-commit or pull-request, got '${{ inputs.MODE }}'."
+              exit 1
+              ;;
+          esac
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.MODE == 'direct-commit' && inputs.TARGET_BRANCH || github.ref }}
+
+      - name: Bump value
+        env:
+          VALUES_FILE: ${{ inputs.VALUES_FILE }}
+          YQ_PATH: ${{ inputs.YQ_PATH }}
+          IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
+        run: |
+          yq -i "${YQ_PATH} = strenv(IMAGE_TAG)" "${VALUES_FILE}"
+
+      - name: Commit directly to target branch
+        if: ${{ inputs.MODE == 'direct-commit' }}
+        env:
+          VALUES_FILE: ${{ inputs.VALUES_FILE }}
+          IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
+          TARGET_BRANCH: ${{ inputs.TARGET_BRANCH }}
+          COMMIT_MESSAGE: ${{ inputs.COMMIT_MESSAGE }}
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add "${VALUES_FILE}"
+          git diff --cached --quiet && exit 0
+          MSG="${COMMIT_MESSAGE:-chore: update image tag to ${IMAGE_TAG} [skip ci]}"
+          git commit -m "${MSG}"
+          git pull --rebase origin "${TARGET_BRANCH}"
+          git push origin "${TARGET_BRANCH}"
+
+      - name: Open review PR
+        if: ${{ inputs.MODE == 'pull-request' }}
+        env:
+          VALUES_FILE: ${{ inputs.VALUES_FILE }}
+          IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
+          TARGET_BRANCH: ${{ inputs.TARGET_BRANCH }}
+          PR_BRANCH: ${{ inputs.PR_BRANCH_PREFIX }}${{ inputs.IMAGE_TAG }}
+          PR_TITLE: ${{ inputs.PR_TITLE }}
+          PR_BODY: ${{ inputs.PR_BODY }}
+          COMMIT_MESSAGE: ${{ inputs.COMMIT_MESSAGE }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git checkout -b "${PR_BRANCH}"
+          git add "${VALUES_FILE}"
+          MSG="${COMMIT_MESSAGE:-chore: release ${IMAGE_TAG} [skip ci]}"
+          git commit -m "${MSG}"
+          git push origin "${PR_BRANCH}"
+
+          TITLE="${PR_TITLE:-Release ${IMAGE_TAG} to ${TARGET_BRANCH}}"
+          if [ -n "${PR_BODY}" ]; then
+            printf '%s\n' "${PR_BODY}" > /tmp/pr-body.md
+          else
+            printf '%s\n' \
+              "Automated GitOps PR — updates \`${VALUES_FILE}\` to image tag \`${IMAGE_TAG}\`." \
+              "" \
+              "**Review checklist:**" \
+              "- [ ] Staging smoke tests passed" \
+              "- [ ] No outstanding incidents" \
+              "" \
+              "Merging this PR will update the target Application on the next sync." \
+              > /tmp/pr-body.md
+          fi
+
+          gh pr create \
+            --title "${TITLE}" \
+            --body-file /tmp/pr-body.md \
+            --base "${TARGET_BRANCH}" \
+            --head "${PR_BRANCH}"

--- a/.github/workflows/go-test-with-services.yml
+++ b/.github/workflows/go-test-with-services.yml
@@ -1,0 +1,107 @@
+name: Go tests with service containers
+
+# Reusable workflow: Go build/vet/format/lint/vulncheck (via ./.github/actions/test-go)
+# plus `go test` against Mongo + Redis service containers. A composite action can't
+# declare job-level `services:`, so this exists as its own workflow rather than an
+# action — use it when your Go tests need a real DB/cache, not just ci-check.yml.
+
+on:
+  workflow_call:
+    inputs:
+      GO_VERSION:
+        required: false
+        type: string
+        default: ''
+        description: 'Go version to use. Defaults to go.mod if not set.'
+      MONGO_VERSION:
+        required: false
+        type: string
+        default: '7.0'
+      REDIS_VERSION:
+        required: false
+        type: string
+        default: '7-alpine'
+      TEST_ENV:
+        required: false
+        type: string
+        default: ''
+        description: 'Extra env for the `go test` step, one KEY=VALUE per line (e.g. MONGO_TEST_HOST=127.0.0.1).'
+      GOPRIVATE:
+        required: false
+        type: string
+        default: ''
+        description: 'GOPRIVATE pattern, e.g. github.com/org/*. Requires PRIVATE_GO_MODULES_TOKEN if set.'
+      RUN_LINT:
+        required: false
+        type: boolean
+        default: true
+      RUN_VULNCHECK:
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      PRIVATE_GO_MODULES_TOKEN:
+        required: false
+        description: 'PAT with read access to GOPRIVATE modules.'
+
+jobs:
+  test:
+    name: Go test (with services)
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:${{ inputs.MONGO_VERSION }}
+        ports: ['27017:27017']
+        env:
+          MONGO_INITDB_ROOT_USERNAME: root
+          MONGO_INITDB_ROOT_PASSWORD: rootpassword
+        options: >-
+          --health-cmd "mongosh --quiet -u root -p \"$MONGO_INITDB_ROOT_PASSWORD\" --authenticationDatabase admin --eval \"db.adminCommand({ ping: 1 })\""
+          --health-interval 5s
+          --health-timeout 10s
+          --health-retries 12
+          --health-start-period 20s
+      redis:
+        image: redis:${{ inputs.REDIS_VERSION }}
+        ports: ['6379:6379']
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Checkout actions
+        uses: actions/checkout@v7
+        with:
+          repository: signalwire/actions-template
+          ref: main
+          path: actions
+
+      - name: Configure Git for private Go modules
+        if: ${{ inputs.GOPRIVATE != '' }}
+        env:
+          TOKEN: ${{ secrets.PRIVATE_GO_MODULES_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          git config --global url."https://x-access-token:${TOKEN}@github.com/${OWNER}/".insteadOf "https://github.com/${OWNER}/"
+
+      - name: Build, vet, format, lint, vulncheck
+        uses: ./actions/.github/actions/test-go
+        with:
+          GO_VERSION: ${{ inputs.GO_VERSION }}
+          RUN_TESTS: false
+          RUN_LINT: ${{ inputs.RUN_LINT }}
+          RUN_VULNCHECK: ${{ inputs.RUN_VULNCHECK }}
+
+      - name: Run tests
+        env:
+          TEST_ENV: ${{ inputs.TEST_ENV }}
+        run: |
+          set -a
+          while IFS= read -r line; do
+            [ -n "$line" ] && export "${line?}"
+          done <<< "$TEST_ENV"
+          set +a
+          go test ./... -count=1

--- a/.github/workflows/go-test-with-services.yml
+++ b/.github/workflows/go-test-with-services.yml
@@ -17,6 +17,15 @@ on:
         required: false
         type: string
         default: '7.0'
+      MONGO_ROOT_USERNAME:
+        required: false
+        type: string
+        default: 'root'
+        description: 'Set both this and MONGO_ROOT_PASSWORD to empty strings to run Mongo with auth disabled.'
+      MONGO_ROOT_PASSWORD:
+        required: false
+        type: string
+        default: 'rootpassword'
       REDIS_VERSION:
         required: false
         type: string
@@ -53,10 +62,12 @@ jobs:
         image: mongo:${{ inputs.MONGO_VERSION }}
         ports: ['27017:27017']
         env:
-          MONGO_INITDB_ROOT_USERNAME: root
-          MONGO_INITDB_ROOT_PASSWORD: rootpassword
+          MONGO_INITDB_ROOT_USERNAME: ${{ inputs.MONGO_ROOT_USERNAME }}
+          MONGO_INITDB_ROOT_PASSWORD: ${{ inputs.MONGO_ROOT_PASSWORD }}
+        # `ping` doesn't require auth even with a root user configured, so this
+        # health-cmd works the same whether MONGO_ROOT_USERNAME/PASSWORD are set or empty.
         options: >-
-          --health-cmd "mongosh --quiet -u root -p \"$MONGO_INITDB_ROOT_PASSWORD\" --authenticationDatabase admin --eval \"db.adminCommand({ ping: 1 })\""
+          --health-cmd "mongosh --quiet --eval \"db.adminCommand({ ping: 1 })\""
           --health-interval 5s
           --health-timeout 10s
           --health-retries 12

--- a/.github/workflows/helm-oci-push.yml
+++ b/.github/workflows/helm-oci-push.yml
@@ -1,0 +1,140 @@
+name: Helm chart OCI push & sign
+
+# Reusable workflow: packages a Helm chart, pushes it to an OCI registry, and
+# optionally signs the pushed digest with Cosign via a GCP KMS key. Chart version
+# is ref-aware: v* tag -> tag sans v, DEV_BRANCH -> <base>-dev.<shortsha>,
+# anything else -> <base>-ci.<shortsha> — unless CHART_VERSION overrides it.
+
+on:
+  workflow_call:
+    inputs:
+      CHART_DIR:
+        required: true
+        type: string
+        description: 'Path to the Helm chart directory (containing Chart.yaml).'
+      IMAGE_REPO:
+        required: true
+        type: string
+        description: 'OCI repo, e.g. us-east1-docker.pkg.dev/<project>/<repo>.'
+      WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+        type: string
+      PROJECT_ID:
+        required: true
+        type: string
+      DEV_BRANCH:
+        required: false
+        type: string
+        default: 'dev'
+        description: 'Branch that gets a -dev.<shortsha> version instead of -ci.<shortsha>.'
+      CHART_VERSION:
+        required: false
+        type: string
+        default: ''
+        description: 'Explicit chart version override. If empty, derived from the ref.'
+      ENABLE_COSIGN_SIGN:
+        required: false
+        type: boolean
+        default: false
+      KMS_KEY_PATH:
+        required: false
+        type: string
+        default: ''
+        description: 'GCP KMS key resource path for Cosign signing. Required when ENABLE_COSIGN_SIGN is true.'
+    outputs:
+      chart_version:
+        description: 'The chart version that was pushed.'
+        value: ${{ jobs.helm-push.outputs.chart_version }}
+
+jobs:
+  helm-push:
+    name: Push Helm chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      chart_version: ${{ steps.push.outputs.chart_version }}
+    steps:
+      - name: Validate signing inputs
+        run: |
+          if [ "${{ inputs.ENABLE_COSIGN_SIGN }}" = "true" ] && [ -z "${{ inputs.KMS_KEY_PATH }}" ]; then
+            echo "::error::ENABLE_COSIGN_SIGN is true but KMS_KEY_PATH is empty."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ inputs.WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ inputs.PROJECT_ID }}
+
+      - uses: google-github-actions/setup-gcloud@v3.0.1
+
+      - name: Authenticate Docker to Artifact Registry
+        run: gcloud auth configure-docker "$(echo '${{ inputs.IMAGE_REPO }}' | cut -d/ -f1)" --quiet
+
+      - uses: azure/setup-helm@v5
+
+      - name: Package and push chart (OCI)
+        id: push
+        env:
+          CHART_DIR: ${{ inputs.CHART_DIR }}
+          IMAGE_REPO: ${{ inputs.IMAGE_REPO }}
+          DEV_BRANCH: ${{ inputs.DEV_BRANCH }}
+          CHART_VERSION_OVERRIDE: ${{ inputs.CHART_VERSION }}
+        run: |
+          BASE_VERSION="$(awk -F': ' '/^version:/{print $2}' "${CHART_DIR}/Chart.yaml" | tr -d '"')"
+          if [ -z "${BASE_VERSION}" ]; then
+            echo "::error::Could not read chart version from ${CHART_DIR}/Chart.yaml"
+            exit 1
+          fi
+
+          if [ -n "${CHART_VERSION_OVERRIDE}" ]; then
+            CHART_VERSION="${CHART_VERSION_OVERRIDE}"
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            CHART_VERSION="${GITHUB_REF_NAME#v}"
+          elif [[ "${GITHUB_REF}" == "refs/heads/${DEV_BRANCH}" ]]; then
+            CHART_VERSION="${BASE_VERSION}-dev.$(echo "${GITHUB_SHA}" | cut -c1-7)"
+          else
+            CHART_VERSION="${BASE_VERSION}-ci.$(echo "${GITHUB_SHA}" | cut -c1-7)"
+          fi
+          echo "Helm OCI chart version: ${CHART_VERSION} (Chart.yaml base: ${BASE_VERSION})"
+
+          CHART_NAME="$(awk -F': ' '/^name:/{print $2}' "${CHART_DIR}/Chart.yaml" | tr -d '"')"
+          CHART_PKG="${CHART_NAME}-${CHART_VERSION}.tgz"
+          helm dependency build "${CHART_DIR}"
+          helm package "${CHART_DIR}" --destination . --version "${CHART_VERSION}"
+          gcloud auth print-access-token | helm registry login -u oauth2accesstoken --password-stdin "$(echo "${IMAGE_REPO}" | cut -d/ -f1)"
+          helm push "${CHART_PKG}" "oci://${IMAGE_REPO}"
+
+          echo "chart_version=${CHART_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "chart_name=${CHART_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Cosign
+        if: ${{ inputs.ENABLE_COSIGN_SIGN }}
+        uses: sigstore/cosign-installer@v3
+
+      # RSA-PKCS1 KMS keys fail Rekor verification, so --tlog-upload is disabled —
+      # the registry plus GCP Cloud Audit Logs are the audit trail (matches
+      # container-build-sign.yml's image-signing rationale).
+      - name: Sign chart
+        if: ${{ inputs.ENABLE_COSIGN_SIGN }}
+        env:
+          IMAGE_REPO: ${{ inputs.IMAGE_REPO }}
+          CHART_NAME: ${{ steps.push.outputs.chart_name }}
+          CHART_VERSION: ${{ steps.push.outputs.chart_version }}
+          KMS_KEY_PATH: ${{ inputs.KMS_KEY_PATH }}
+        run: |
+          CHART_REF="${IMAGE_REPO}/${CHART_NAME}:${CHART_VERSION}"
+          DIGEST=$(gcloud artifacts docker images describe "${CHART_REF}" --format='value(image_summary.digest)')
+          TOKEN=$(gcloud auth print-access-token)
+          cosign sign \
+            --key "gcpkms://${KMS_KEY_PATH}" \
+            --tlog-upload=false \
+            --yes \
+            --registry-username=oauth2accesstoken \
+            --registry-password="${TOKEN}" \
+            "${IMAGE_REPO}/${CHART_NAME}@${DIGEST}"

--- a/.github/workflows/helm-oci-push.yml
+++ b/.github/workflows/helm-oci-push.yml
@@ -86,7 +86,7 @@ jobs:
           DEV_BRANCH: ${{ inputs.DEV_BRANCH }}
           CHART_VERSION_OVERRIDE: ${{ inputs.CHART_VERSION }}
         run: |
-          BASE_VERSION="$(awk -F': ' '/^version:/{print $2}' "${CHART_DIR}/Chart.yaml" | tr -d '"')"
+          BASE_VERSION="$(yq '.version' "${CHART_DIR}/Chart.yaml")"
           if [ -z "${BASE_VERSION}" ]; then
             echo "::error::Could not read chart version from ${CHART_DIR}/Chart.yaml"
             exit 1
@@ -103,7 +103,7 @@ jobs:
           fi
           echo "Helm OCI chart version: ${CHART_VERSION} (Chart.yaml base: ${BASE_VERSION})"
 
-          CHART_NAME="$(awk -F': ' '/^name:/{print $2}' "${CHART_DIR}/Chart.yaml" | tr -d '"')"
+          CHART_NAME="$(yq '.name' "${CHART_DIR}/Chart.yaml")"
           CHART_PKG="${CHART_NAME}-${CHART_VERSION}.tgz"
           helm dependency build "${CHART_DIR}"
           helm package "${CHART_DIR}" --destination . --version "${CHART_VERSION}"

--- a/.github/workflows/reusable-cypress-stack.yml
+++ b/.github/workflows/reusable-cypress-stack.yml
@@ -1,0 +1,155 @@
+name: Reusable Cypress full stack
+
+# Reusable workflow: brings up a caller repo's full local dev stack (Go
+# services + Vault + Mongo + Redis + UI) via its own Makefile, seeds an
+# admin user, and runs Cypress against it. Requires the caller repo to
+# provide `make go-build`, `make up-app`, `make seed`, `make down`
+# targets matching the env/ports below.
+
+on:
+  workflow_call:
+    inputs:
+      cypress_spec:
+        description: Cypress --spec value (paths relative to ui/)
+        required: true
+        type: string
+      job_name:
+        description: Job display name in GitHub Checks
+        required: false
+        type: string
+        default: Cypress E2E
+    secrets:
+      PRIVATE_GO_MODULES_TOKEN:
+        required: true
+      CYPRESS_LOGIN_PASSWORD:
+        required: false
+
+env:
+  GO_VERSION: '1.26'
+  GOPRIVATE: github.com/signalwire/*
+  GONOSUMDB: github.com/signalwire/*
+
+jobs:
+  cypress:
+    name: ${{ inputs.job_name }}
+    runs-on: ubuntu-latest
+    env:
+      CYPRESS_BASE_URL: http://127.0.0.1:5173
+      # Must match Makefile default so make up-app and wait-on use the same URL.
+      ORCHESTRATOR_HTTP_ADDR: 127.0.0.1:8080
+      # Vault dynamic users authenticate via admin (see build/vault-server/entrypoint.sh).
+      MONGO_URI: mongodb://127.0.0.1:27017/?authSource=admin&directConnection=true
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Configure Git for private Go modules
+        run: |
+          if [ -z "${TOKEN}" ]; then
+            echo "::error::Set repository secret PRIVATE_GO_MODULES_TOKEN to a GitHub PAT with read access to github.com/signalwire/go-vaultdbauth"
+            exit 1
+          fi
+          git config --global url."https://x-access-token:${TOKEN}@github.com/signalwire/".insteadOf "https://github.com/signalwire/"
+        env:
+          TOKEN: ${{ secrets.PRIVATE_GO_MODULES_TOKEN }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Restore Go modules cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Restore Node modules cache
+        id: node-cache
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ui/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('ui/package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: npm ci
+        working-directory: ui
+
+      - name: Cache Cypress binary
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('ui/package-lock.json') }}
+
+      - name: Install Cypress binary
+        run: npx cypress install
+        working-directory: ui
+
+      - name: Pre-build Go services
+        run: make go-build
+        env:
+          GOTOOLCHAIN: local
+
+      - name: Start full stack and wait for readiness
+        run: |
+          mkdir -p build/data
+          rm -f build/data/secret*
+          chmod 777 build/data
+          nohup make up-app </dev/null > /tmp/up-app.log 2>&1 &
+          echo $! > /tmp/up-app.pid
+
+          tail -f /tmp/up-app.log &
+          TAIL_PID=$!
+
+          cd ui && npx wait-on \
+            "http://${ORCHESTRATOR_HTTP_ADDR}/healthz" \
+            "http://127.0.0.1:8081/healthz" \
+            "${CYPRESS_BASE_URL}" \
+            --timeout 480000
+
+          kill $TAIL_PID 2>/dev/null || true
+
+      - name: Seed admin user
+        run: make seed
+        env:
+          MONGO_FLAGS: authSource=admin
+          MONGO_DATABASE: platform_orchestrator
+          VAULT_ADDRESS: http://127.0.0.1:8200
+          VAULT_APPROLE_ROLE_ID: my-role
+
+      - name: Run Cypress
+        run: npx cypress run --spec "${{ inputs.cypress_spec }}"
+        working-directory: ui
+        env:
+          CYPRESS_LOGIN_EMAIL: ${{ vars.CYPRESS_LOGIN_EMAIL || 'admin@local' }}
+          CYPRESS_LOGIN_PASSWORD: ${{ secrets.CYPRESS_LOGIN_PASSWORD || 'admin' }}
+
+      - name: Upload Cypress screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ui/cypress/screenshots
+          if-no-files-found: ignore
+
+      - name: Upload full-stack startup logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-full-stack-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/up-app.log
+          if-no-files-found: ignore
+
+      - name: Stop full stack
+        if: always()
+        run: |
+          make down || true
+          if [ -f /tmp/up-app.pid ]; then
+            kill "$(cat /tmp/up-app.pid)" 2>/dev/null || true
+          fi

--- a/.github/workflows/reusable-cypress-stack.yml
+++ b/.github/workflows/reusable-cypress-stack.yml
@@ -3,8 +3,8 @@ name: Reusable Cypress full stack
 # Reusable workflow: brings up a caller repo's full local dev stack (Go
 # services + Vault + Mongo + Redis + UI) via its own Makefile, seeds an
 # admin user, and runs Cypress against it. Requires the caller repo to
-# provide `make go-build`, `make up-app`, `make seed`, `make down`
-# targets matching the env/ports below.
+# provide `make up-app`, `make seed`, `make down` targets matching the
+# env/ports below (plus `make go-build` when ENABLE_GO is true).
 
 on:
   workflow_call:
@@ -18,9 +18,15 @@ on:
         required: false
         type: string
         default: Cypress E2E
+      ENABLE_GO:
+        description: Set up Go, restore its module cache, and run `make go-build` before bringing up the stack. Disable for callers whose stack doesn't need Go.
+        required: false
+        type: boolean
+        default: true
     secrets:
       PRIVATE_GO_MODULES_TOKEN:
-        required: true
+        required: false
+        description: Required when ENABLE_GO is true.
       CYPRESS_LOGIN_PASSWORD:
         required: false
 
@@ -43,6 +49,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Configure Git for private Go modules
+        if: ${{ inputs.ENABLE_GO }}
         run: |
           if [ -z "${TOKEN}" ]; then
             echo "::error::Set repository secret PRIVATE_GO_MODULES_TOKEN to a GitHub PAT with read access to github.com/signalwire/go-vaultdbauth"
@@ -53,11 +60,13 @@ jobs:
           TOKEN: ${{ secrets.PRIVATE_GO_MODULES_TOKEN }}
 
       - uses: actions/setup-go@v6
+        if: ${{ inputs.ENABLE_GO }}
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
       - name: Restore Go modules cache
+        if: ${{ inputs.ENABLE_GO }}
         uses: actions/cache/restore@v6.1.0
         with:
           path: |
@@ -92,6 +101,7 @@ jobs:
         working-directory: ui
 
       - name: Pre-build Go services
+        if: ${{ inputs.ENABLE_GO }}
         run: make go-build
         env:
           GOTOOLCHAIN: local


### PR DESCRIPTION
## Summary

Reusable workflows to support converting per-repo CI pipelines (platform-orchestrator, ipam, pricing-calculator, platform-mcp) onto shared building blocks:

- **`go-test-with-services.yml`** — Go build/vet/format/lint/vulncheck (via `./.github/actions/test-go`) plus `go test` against Mongo + Redis service containers. A composite action can't declare job-level `services:`, so this is its own workflow. Mongo root auth is optional (`MONGO_ROOT_USERNAME`/`PASSWORD`, both empty = no-auth) to support callers whose tests expect an unauthenticated Mongo.
- **`helm-oci-push.yml`** — packages a Helm chart, pushes it to an OCI registry, optionally signs the digest with Cosign via a GCP KMS key. Ref-aware versioning (`v*` tag / dev branch / other), mirroring `container-build-sign.yml`'s conventions (WIF auth, `--tlog-upload=false` rationale).
- **`gitops-values-bump.yml`** — bumps an image tag in a Helm values file, either a direct commit (auto-deploy to dev) or opening a review PR (gated production release).
- **`reusable-cypress-stack.yml`** — full-stack Cypress E2E workflow, copied from platform-orchestrator so it can be referenced from actions-template instead of a local copy. `ENABLE_GO` (default true) gates the Go setup/build steps for callers whose stack doesn't need Go.
- **`container-build-sign.yml`** (pre-existing, extended) — adds `PUSH_IMAGES` (default true) so callers can build-only without pushing (e.g. PR validation), instead of always pushing unconditionally.

These complement the existing `ci-check.yml` (lint/security gates), which already covers the rest.

## Review feedback addressed
- Fixed `gitops-values-bump.yml`'s `pull-request` mode checking out `github.ref` instead of `TARGET_BRANCH` — the resulting PR would have included whatever diverged between the triggering ref and `TARGET_BRANCH`, not just the intended tag bump.
- Added a fail-fast validation in `container-build-sign.yml` for `PUSH_IMAGES: false` + multi-platform `PLATFORMS` (buildx `--load` can't load a multi-platform manifest).
- `helm-oci-push.yml` now reads `Chart.yaml`'s version/name with `yq` instead of `awk`/`tr`, consistent with `gitops-values-bump.yml`'s existing `yq` dependency in this same PR.
- Aligned `container-build-sign.yml`'s action versions with the rest of this PR's new files (`actions/checkout@v7`, `google-github-actions/auth@v3`, `docker/setup-buildx-action@v4`, `actions/upload-artifact@v7`).

## Test plan
- [ ] YAML-validated (`ruby -ryaml`) — all files parse cleanly
- [ ] Exercised end-to-end via platform-orchestrator/ipam/pricing-calculator/platform-mcp PRs that call these (see their respective PRs)
