### PR TITLE
fix: gitops-values-bump.yml pull-request mode can't create PRs under org PR-creation policy

### DIFF
--- a/.github/workflows/gitops-values-bump.yml
+++ b/.github/workflows/gitops-values-bump.yml
@@ -50,6 +50,15 @@ on:
         type: string
         default: ''
         description: 'Defaults to "chore: update image tag to <IMAGE_TAG> [skip ci]" if empty.'
+      APP_ID:
+        required: false
+        type: string
+        default: ''
+        description: 'GitHub App ID used to mint a PR-creation token for MODE: pull-request. Unused (and optional) in direct-commit mode.'
+    secrets:
+      APP_PRIVATE_KEY:
+        required: false
+        description: 'Private key for APP_ID. Required when MODE is pull-request — the reusable GITHUB_TOKEN often cannot open PRs (org policy), so pull-request mode always authenticates as this App instead.'
 
 jobs:
   validate:
@@ -64,6 +73,34 @@ jobs:
               exit 1
               ;;
           esac
+      - if: ${{ inputs.MODE == 'pull-request' && inputs.APP_ID == '' }}
+        run: |
+          echo "::error::APP_ID is required when MODE is pull-request."
+          exit 1
+
+  # Mints a short-lived token from a GitHub App to open the review PR.
+  # pull-request mode never relies on the reusable GITHUB_TOKEN for this —
+  # many orgs disable "Allow GitHub Actions to create pull requests" as
+  # policy, which makes GITHUB_TOKEN-based PR creation fail workflow
+  # *validation* entirely (not just at runtime) the moment a caller's job
+  # requests pull-requests: write. An externally-authenticated App token
+  # isn't subject to that restriction and needs no permissions grant from
+  # the caller at all.
+  generate-token:
+    name: Generate GitOps PR token
+    needs: [validate]
+    if: ${{ inputs.MODE == 'pull-request' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      token: ${{ steps.generate-token.outputs.token }}
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ inputs.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
   direct-commit:
     name: Bump ${{ inputs.YQ_PATH }} -> ${{ inputs.IMAGE_TAG }} (direct commit)
@@ -103,16 +140,18 @@ jobs:
 
   pull-request:
     name: Bump ${{ inputs.YQ_PATH }} -> ${{ inputs.IMAGE_TAG }} (PR)
-    needs: [validate]
+    needs: [validate, generate-token]
     if: ${{ inputs.MODE == 'pull-request' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    # No GITHUB_TOKEN permissions requested — all git/gh operations below
+    # authenticate as the App token from generate-token instead, so this
+    # job's validity doesn't depend on the org's GITHUB_TOKEN PR policy.
+    permissions: {}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.TARGET_BRANCH }}
+          token: ${{ needs.generate-token.outputs.token }}
 
       - name: Bump value
         env:
@@ -131,7 +170,7 @@ jobs:
           PR_TITLE: ${{ inputs.PR_TITLE }}
           PR_BODY: ${{ inputs.PR_BODY }}
           COMMIT_MESSAGE: ${{ inputs.COMMIT_MESSAGE }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ needs.generate-token.outputs.token }}
         run: |
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Problem
`pull-request` mode hardcoded `GH_TOKEN: ${{ github.token }}` and requested `permissions: pull-requests: write` from the caller. Any org that disables "Allow GitHub Actions to create and approve pull requests" (a common security policy — confirmed the case for at least one caller) rejects that permissions request at **workflow validation time**, not just at runtime. That means the moment any caller's job requests `pull-requests: write` and the org denies it, the *entire calling workflow file* becomes invalid — breaking CI for every trigger (PRs, pushes, tags), not just the release path that actually needed the PR.

Found and worked around downstream in signalwire/pricing-calculator#46 with a repo-local inline job; this PR fixes it at the source so other callers don't have to do the same workaround.

## Fix
- Add optional `APP_ID` input + `APP_PRIVATE_KEY` secret to the reusable workflow.
- New `generate-token` job mints a short-lived installation token from that GitHub App when `MODE == pull-request`.
- `pull-request` job now authenticates its `checkout` and `gh pr create` with that App token instead of `github.token`, and requests **no permissions at all** (`permissions: {}`) — an externally-authenticated App token isn't subject to the org's `GITHUB_TOKEN`-specific PR-creation restriction, so there's nothing to grant.
- `validate` job now errors clearly if `MODE: pull-request` is used without `APP_ID`.

## Compatibility
- `direct-commit` mode is untouched (only ever needed `contents: write`, unaffected by this policy) — existing callers using that mode need zero changes.
- Existing callers using `pull-request` mode will need to add `APP_ID`/`APP_PRIVATE_KEY` to their call (required, not optional — there's no way to create a PR without an authorized token when GITHUB_TOKEN is blocked org-wide).

## Test plan
- [ ] Verify a caller using `direct-commit` mode still works unchanged
- [ ] Verify a caller using `pull-request` mode with `APP_ID`/`APP_PRIVATE_KEY` set successfully opens a PR
- [ ] Verify a caller using `pull-request` mode without `APP_ID` fails fast with a clear validation error, not a permissions error
